### PR TITLE
Additional tenure update steps

### DIFF
--- a/aws/src/database/multi_table/amend_tenure.py
+++ b/aws/src/database/multi_table/amend_tenure.py
@@ -24,7 +24,7 @@ while PARAM_KEY_ES not in ["startOfTenureDate", "endOfTenureDate"]:
     if start_or_end in ["e", "end"]:
         PARAM_KEY_ES = "endOfTenureDate"
 
-UPDATE_DATE = parser.parse(timestr=input("Enter a date: ").strip(),
+UPDATE_DATE = parser.parse(timestr=input("Enter a date (e.g. DD/MM/YYYY or YYYY-MM-DD): ").strip(),
                            parserinfo=parser.parserinfo(dayfirst=True)).isoformat()
 PARAM_KEY_DYNAMO_TENURE = PARAM_KEY_ES
 PARAM_KEY_DYNAMO_ASSET = PARAM_KEY_ES
@@ -50,7 +50,7 @@ def main():
     print(f"Param key: {PARAM_KEY_ES}")
     print(f"New value: {UPDATE_DATE}")
     _confirm("Correct?")
-    
+
     tenure = get_tenure_dynamodb(TENURE_ID)
 
     update_dynamodb = _confirm(f"Update {STAGE.value} DynamoDB?", kill=False)

--- a/aws/src/database/multi_table/amend_tenure.py
+++ b/aws/src/database/multi_table/amend_tenure.py
@@ -202,23 +202,26 @@ def update_persons_dynamodb(tenure_item: dict):
                 person_tenures[i][PARAM_KEY_DYNAMO_PERSON] = NEW_PARAM_VALUE.split('T')[0]
                 print(tenure['assetFullAddress'])
         print(f"Update tenure for person {tenure_person['id']}, {tenure_person['fullName']}?")
-        _confirm(f"Confirm updating this person's tenure {PARAM_KEY_DYNAMO_PERSON}?")
 
-        persons_table.update_item(
-            Key={"id": tenure_person['id']},
-            UpdateExpression=f"set tenures = :r",
-            ExpressionAttributeValues={
-                ":r": person_tenures
-            },
-            ReturnValues="UPDATED_NEW"
-        )
+        if _confirm(f"Confirm updating this person's tenure {PARAM_KEY_DYNAMO_PERSON}?", kill=False):
+            persons_table.update_item(
+                Key={"id": tenure_person['id']},
+                UpdateExpression=f"set tenures = :r",
+                ExpressionAttributeValues={
+                    ":r": person_tenures
+                },
+                ReturnValues="UPDATED_NEW"
+            )
 
 
-def _confirm(question):
-    confirm = input(f"{question} (y/n): ")
-    if confirm.lower() not in ["y", "yes"]:
+def _confirm(question: str, kill=True):
+    confirm = input(f"{question} (y/n): ").lower() not in ["y", "yes"]
+    if confirm and kill:
         print("Exiting")
         exit()
+    if confirm:  # No kill / exit
+        return False
+    return True
 
 
 if __name__ == "__main__":

--- a/aws/src/database/multi_table/amend_tenure.py
+++ b/aws/src/database/multi_table/amend_tenure.py
@@ -50,17 +50,20 @@ def main():
     print(f"Param key: {PARAM_KEY_ES}")
     print(f"New value: {UPDATE_DATE}")
     _confirm("Correct?")
+    
     tenure = get_tenure_dynamodb(TENURE_ID)
-    update_es = _confirm(f"Update {STAGE.value} Elasticsearch?", kill=False)
-    if update_es:
-        connect_to_jumpbox_for_es(instance_id=INSTANCE_ID, stage=STAGE.value)
-        update_tenure_elasticsearch(tenure_pk=TENURE_ID)
-        update_property_elasticsearch(property_pk=tenure["tenuredAsset"]["id"])
+
     update_dynamodb = _confirm(f"Update {STAGE.value} DynamoDB?", kill=False)
     if update_dynamodb:
         update_tenure_dynamodb(tenure)
         update_property_dynamodb(tenure)
         update_persons_dynamodb(tenure)
+
+    update_es = _confirm(f"Update {STAGE.value} Elasticsearch?", kill=False)
+    if update_es:
+        connect_to_jumpbox_for_es(instance_id=INSTANCE_ID, stage=STAGE.value)
+        update_tenure_elasticsearch(tenure_pk=TENURE_ID)
+        update_property_elasticsearch(property_pk=tenure["tenuredAsset"]["id"])
 
 
 def connect_to_jumpbox_for_es(instance_id=INSTANCE_ID, stage=STAGE.value):

--- a/aws/src/database/multi_table/input/elasticsearch_query_asset.py
+++ b/aws/src/database/multi_table/input/elasticsearch_query_asset.py
@@ -1,0 +1,12 @@
+import json
+import sys
+
+data = json.load(sys.stdin)
+hits = data["hits"]["hits"]
+for hit in hits:
+    source = hit["_source"]
+    end_date = source["tenure"].get("endOfTenureDate") and source["tenure"]["endOfTenureDate"].split("T")[0]
+    print("\n == Asset ID: " + source["id"] + " == ")
+    print("Address: " + source["assetAddress"]["addressLine1"])
+    print("Start of tenure: " + source["tenure"]["startOfTenureDate"].split("T")[0])
+    print("End of tenure: " + (end_date if end_date else "None"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ sqlalchemy>=2.0.9
 google>=3.0.0
 google-api-python-client>=2.86.0
 pyperclip~=1.8.2
+python-dateutil~=2.8.2


### PR DESCRIPTION
This extends the tenure update script to also update the tenure in the property elasticsearch, as well as to go through each householdmember of a tenure and choose to update their tenure start/end dates.