### PR TITLE
Safe dictionary to object conversion

### DIFF
--- a/aws/src/database/domain/dynamo_domain_objects.py
+++ b/aws/src/database/domain/dynamo_domain_objects.py
@@ -1,7 +1,55 @@
 from _decimal import Decimal
 from dataclasses import dataclass
 
+from aws.src.utils.safe_object_from_dict import safe_object_from_dict
 
+# --- Tenure Table ---
+@dataclass
+class TenuredAsset:
+    id: str
+    fullAddress: str | None
+    propertyReference: str | None
+    uprn: str | None
+    type: str | None
+
+
+@dataclass
+class HouseholdMember:
+    id: str
+    fullName: str | None
+    dateOfBirth: str | None
+    isResponsible: bool | None
+    personTenureType: str | None
+    type: str | None
+
+
+@dataclass
+class Tenure:
+    id: str
+    charges: dict | None
+    endOfTenureDate: str | None
+    evictionDate: str | None
+    householdMembers: list[HouseholdMember] | None
+    informHousingBenefitsForChanges: bool | None
+    isMutalExchange: bool | None
+    isSublet: bool | None
+    legacyReferences: list[dict] | None
+    notices: list[dict] | None
+    paymentReference: str | None
+    potentialEndDate: str | None
+    startOfTenureDate: str | None
+    subletEndDate: str | None
+    successionDate: str | None
+    tenuredAsset: TenuredAsset | None
+    tenureType: dict | None
+    terminated: dict | None
+
+    def __post_init__(self):
+        self.tenuredAsset = safe_object_from_dict(TenuredAsset, self.tenuredAsset)
+        self.householdMembers = [safe_object_from_dict(HouseholdMember, member) for member in self.householdMembers]
+# --- END Tenure Table ---
+
+# --- Person Table ---
 @dataclass
 class PersonTenure:
     id: str
@@ -16,28 +64,6 @@ class PersonTenure:
 
 
 @dataclass
-class Tenure:
-    id: str
-    charges: list[dict] | None
-    endOfTenureDate: str | None
-    evictionDate: str | None
-    householdMembers: list[dict]
-    informHousingBenefitsForChanges: bool | None
-    isMutalExchange: bool | None
-    isSublet: bool | None
-    legacyReferences: list[dict] | None
-    notices: list[dict] | None
-    paymentReference: str | None
-    potentialEndDate: str | None
-    startOfTenureDate: str | None
-    subletEndDate: str | None
-    successionDate: str | None
-    tenuredAsset: dict | None
-    tenureType: dict | None
-    terminated: dict | None
-
-
-@dataclass
 class Person:
     id: str
     title: str | None
@@ -48,7 +74,12 @@ class Person:
     personTypes: list[str]
     tenures: list[PersonTenure]
 
+    def __post_init__(self):
+        self.tenures = [safe_object_from_dict(PersonTenure, tenure) for tenure in self.tenures]
+# --- END Person Table ---
 
+
+# --- Asset Table ---
 @dataclass
 class ResponsibleEntity:
     id: str
@@ -65,6 +96,10 @@ class Patch:
     patchType: str | None
     responsibleEntities: list[ResponsibleEntity]
     versionNumber: Decimal | None
+
+    def __post_init__(self):
+        self.responsibleEntities = [safe_object_from_dict(ResponsibleEntity, entity) for entity in
+                                    self.responsibleEntities]
 
 
 @dataclass
@@ -90,3 +125,8 @@ class Asset:
     rootAsset: str | None
     tenure: AssetTenure | None
     versionNumber: Decimal | None
+
+    def __post_init__(self):
+        self.tenure = safe_object_from_dict(AssetTenure, self.tenure)
+        self.patches = [safe_object_from_dict(Patch, patch) for patch in self.patches]
+# --- END Asset Table ---

--- a/aws/src/utils/safe_object_from_dict.py
+++ b/aws/src/utils/safe_object_from_dict.py
@@ -1,4 +1,6 @@
-from typing import T
+from typing import TypeVar
+
+T = TypeVar("T")
 
 
 def safe_object_from_dict(object_type: type[T], data: dict) -> T:

--- a/aws/src/utils/safe_object_from_dict.py
+++ b/aws/src/utils/safe_object_from_dict.py
@@ -1,0 +1,25 @@
+from typing import T
+
+
+def safe_object_from_dict(object_type: type[T], data: dict) -> T:
+    """
+    Safely creates an object of the given type from the given dictionary.
+    :param object_type: The type of object to create.
+    :param data: The dictionary containing the data to use for creating the object.
+    :return: An object of the given type, created from the given dictionary.
+    """
+
+    if data is None:
+        return None
+
+    for key in list(data.keys()):
+        if key not in object_type.__annotations__.keys():
+            print(f"WARNING: {key} not in {object_type.__name__}")
+            del data[key]
+
+    for key in object_type.__annotations__.keys():
+        if key not in data.keys():
+            print(f"WARNING: {key} from {object_type.__name__} not in data")
+            data[key] = None
+
+    return object_type(**data)

--- a/aws/tests/conftest.py
+++ b/aws/tests/conftest.py
@@ -5,8 +5,6 @@ import pytest
 from moto import mock_dynamodb
 import random
 
-from src.utils.logger import Logger
-
 
 @pytest.fixture
 def use_mock_dynamodb():

--- a/aws/tests/domain/test_dynamo_domain_objects.py
+++ b/aws/tests/domain/test_dynamo_domain_objects.py
@@ -1,17 +1,243 @@
-from aws.src.database.domain.dynamo_domain_objects import Tenure, HouseholdMember
+import random
+import uuid
 
-def test_generates_tenure():
-    tenure_dict = {
-        "id": '4c148ab7-a58b-a4c2-053a-03bc1684b559',
-        'householdMembers': [
-            {'fullName': 'FAKE_First FAKE_Last', 'isResponsible': True, 'dateOfBirth': '1900-03-02T00:00:00',
-                'personTenureType': 'Tenant', 'id': '713ac847-99fb-c771-5a72-55542a76dcc2', 'type': 'Person'}
-        ]
-    }
+import pytest
 
+from aws.src.database.domain.dynamo_domain_objects import Tenure, HouseholdMember, TenuredAsset, Asset, AssetTenure, \
+    Patch, Person, PersonTenure
+
+
+def test_generates_tenure(tenure_dict: dict):
     tenure = Tenure.from_data(tenure_dict)
 
     assert isinstance(tenure, Tenure)
-    assert tenure.id == '4c148ab7-a58b-a4c2-053a-03bc1684b559'
+    assert tenure.id == str(uuid.uuid4())
+
+    assert isinstance(tenure.tenuredAsset, TenuredAsset)
+    assert tenure.tenuredAsset.id == str(uuid.uuid4())
+
     assert isinstance(tenure.householdMembers[0], HouseholdMember)
     assert tenure.householdMembers[0].fullName == 'FAKE_First FAKE_Last'
+
+
+def test_generates_asset(asset_dict: dict):
+    asset = Asset.from_data(asset_dict)
+
+    assert isinstance(asset, Asset)
+    assert asset.id == asset_dict.get('id')
+    assert asset.assetAddress.get('addressLine1') == asset_dict.get('assetAddress').get('addressLine1')
+
+    assert isinstance(asset.tenure, AssetTenure)
+    assert asset.tenure.id == asset_dict.get('tenure').get('id')
+
+    assert isinstance(asset.patches[0], Patch)
+    assert asset.patches[0].id == asset_dict.get('patches')[0].get('id')
+
+
+def test_generates_person(person_dict: dict):
+    person = Person.from_data(person_dict)
+
+    assert isinstance(person, Person)
+    assert person.id == person_dict.get('id')
+
+    assert isinstance(person.tenures[0], PersonTenure)
+    assert person.tenures[0].id == person_dict.get('tenures')[0].get('id')
+
+
+@pytest.fixture
+def tenure_dict():
+    return {
+        "id": str(uuid.uuid4()),
+        "charges": {
+            "billingFrequency": "Weekly",
+            "combinedRentCharges": 0,
+            "combinedServiceCharges": 0,
+            "currentBalance": 3019.14,
+            "originalRentCharge": 0,
+            "originalServiceCharge": 0,
+            "otherCharges": 0,
+            "rent": 0,
+            "serviceCharge": 0,
+            "tenancyInsuranceCharge": 0
+        },
+        "endOfTenureDate": "2017-11-06",
+        "evictionDate": "1900-01-01",
+        "householdMembers": [
+            {
+                "id": str(uuid.uuid4()),
+                "dateOfBirth": "1066-07-29",
+                "fullName": "FAKE_First FAKE_Last",
+                "isResponsible": True,
+                "personTenureType": "Tenant",
+                "type": "person"
+            }
+        ],
+        "informHousingBenefitsForChanges": False,
+        "isMutualExchange": False,
+        "isSublet": False,
+        "legacyReferences": [
+            {
+                "name": "uh_tag_ref",
+                "value": f"{random.randint(10 ** 7, 10 ** 8 - 1)}/01"
+            },
+            {
+                "name": "u_saff_tenancy",
+                "value": ""
+            }
+        ],
+        "notices": [
+            {
+                "effectiveDate": "1900-01-01",
+                "endDate": None,
+                "expiryDate": "1900-01-01",
+                "servedDate": "1900-01-01",
+                "type": ""
+            }
+        ],
+        "paymentReference": str(random.randint(10 ** 10, 10 ** 11 - 1)),
+        "potentialEndDate": "1900-01-01",
+        "startOfTenureDate": "2017-05-30",
+        "subletEndDate": "1900-01-01",
+        "successionDate": "1900-01-01",
+        "tenuredAsset": {
+            "id": str(uuid.uuid4()),
+            "fullAddress": "THE HACKNEY SERVICE CENTRE 1 Hackney Service Centre E8 1DY",
+            "propertyReference": str(random.randint(10 ** 7, 10 ** 8 - 1)),
+            "type": "Dwelling",
+            "uprn": str(random.randint(10 ** 12, 10 ** 13 - 1))
+        },
+        "tenureType": {
+            "code": "THO",
+            "description": "Temp Hostel"
+        },
+        "terminated": {
+            "isTerminated": True,
+            "reasonForTermination": ""
+        }
+    }
+
+
+@pytest.fixture
+def asset_dict():
+    return {
+        "id": str(uuid.uuid4()),
+        "assetAddress": {
+            "addressLine1": "FLAT 10 220 TEST ROAD",
+            "addressLine2": "HACKNEY",
+            "addressLine3": "LONDON",
+            "postCode": "E8 1AA",
+            "uprn": str(random.randint(10 ** 12, 10 ** 13 - 1))
+        },
+        "assetCharacteristics": {
+            "numberOfBedrooms": 1,
+            "numberOfLifts": 0,
+            "numberOfLivingRooms": 0,
+            "yearConstructed": "0"
+        },
+        "assetId": str(random.randint(10 ** 12, 10 ** 13 - 1)),
+        "assetLocation": {
+            "parentAssets": [
+                {
+                    "id": str(uuid.uuid4()),
+                    "name": "Hackney Homes",
+                    "type": "NA"
+                }
+            ],
+            "totalBlockFloors": 0
+        },
+        "assetManagement": {
+            "isCouncilProperty": False,
+            "isNoRepairsMaintenance": False,
+            "isTMOManaged": False,
+            "managingOrganisation": "London Borough of Hackney",
+            "managingOrganisationId": str(uuid.uuid4()),
+            "owner": "KUS",
+            "propertyOccupiedStatus": "VR"
+        },
+        "assetType": "Dwelling",
+        "isActive": 0,
+        "parentAssetIds": str(uuid.uuid4()),
+        "patches": [
+            {
+                "id": str(uuid.uuid4()),
+                "domain": "MMH",
+                "name": "SN4",
+                "parentId": str(uuid.uuid4()),
+                "patchType": "patch",
+                "responsibleEntities": [
+                    {
+                        "id": str(uuid.uuid4()),
+                        "name": "Fake_First Fake_Last",
+                        "responsibleType": "HousingOfficer"
+                    }
+                ],
+                "versionNumber": None
+            }
+        ],
+        "rootAsset": "ROOT",
+        "tenure": {
+            "id": str(uuid.uuid4()),
+            "endOfTenureDate": "2050-12-12T00:00:00Z",
+            "paymentReference": str(random.randint(10 ** 12, 10 ** 13 - 1)),
+            "startOfTenureDate": "2030-12-12T00:00:00Z",
+            "type": "Secure"
+        },
+        "versionNumber": 3
+    }
+
+
+@pytest.fixture
+def person_dict():
+    return {
+        "id": str(uuid.uuid4()),
+        "dateOfBirth": "1962-04-18T00:00:00.0000000Z",
+        "firstName": "FAKE_First",
+        "lastModified": "2022-09-06T06:31:03.5321566Z",
+        "links": [
+        ],
+        "personTypes": [
+            "Tenant",
+            "HouseholdMember"
+        ],
+        "preferredFirstName": "FAKE_First",
+        "preferredSurname": "FAKE_Last",
+        "preferredTitle": "Reverend",
+        "surname": "FAKE_Last",
+        "tenures": [
+            {
+                "id": str(uuid.uuid4()),
+                "assetFullAddress": "2 Fake Road, N16 1AA",
+                "assetId": str(uuid.uuid4()),
+                "endDate": None,
+                "paymentReference": str(random.randint(10 ** 10, 10 ** 11 - 1)),
+                "propertyReference": str(random.randint(10 ** 7, 10 ** 8 - 1)),
+                "startDate": "2013-12-23",
+                "type": "Secure",
+                "uprn": "100021063882"
+            },
+            {
+                "id": str(uuid.uuid4()),
+                "assetFullAddress": "75 Fake Road, E5 1AA",
+                "assetId": str(uuid.uuid4()),
+                "endDate": "2012-10-26",
+                "paymentReference": str(random.randint(10 ** 10, 10 ** 11 - 1)),
+                "propertyReference": str(random.randint(10 ** 7, 10 ** 8 - 1)),
+                "startDate": "2012-04-19",
+                "type": "Temp Annex",
+                "uprn": str(random.randint(10 ** 12, 10 ** 13 - 1))
+            },
+            {
+                "id": str(uuid.uuid4()),
+                "assetFullAddress": "15 Fake Road N16 1AA",
+                "assetId": str(uuid.uuid4()),
+                "endDate": None,
+                "paymentReference": str(random.randint(10 ** 10, 10 ** 11 - 1)),
+                "propertyReference": str(random.randint(10 ** 7, 10 ** 8 - 1)),
+                "startDate": "1997-07-24T00:00:00.0000000Z",
+                "type": "Leasehold (RTB)",
+                "uprn": str(random.randint(10 ** 12, 10 ** 13 - 1))
+            }
+        ],
+        "title": "Reverend",
+        "versionNumber": 1
+    }

--- a/aws/tests/domain/test_dynamo_domain_objects.py
+++ b/aws/tests/domain/test_dynamo_domain_objects.py
@@ -1,0 +1,17 @@
+from aws.src.database.domain.dynamo_domain_objects import Tenure, HouseholdMember
+
+def test_generates_tenure():
+    tenure_dict = {
+        "id": '4c148ab7-a58b-a4c2-053a-03bc1684b559',
+        'householdMembers': [
+            {'fullName': 'FAKE_First FAKE_Last', 'isResponsible': True, 'dateOfBirth': '1900-03-02T00:00:00',
+                'personTenureType': 'Tenant', 'id': '713ac847-99fb-c771-5a72-55542a76dcc2', 'type': 'Person'}
+        ]
+    }
+
+    tenure = Tenure.from_data(tenure_dict)
+
+    assert isinstance(tenure, Tenure)
+    assert tenure.id == '4c148ab7-a58b-a4c2-053a-03bc1684b559'
+    assert isinstance(tenure.householdMembers[0], HouseholdMember)
+    assert tenure.householdMembers[0].fullName == 'FAKE_First FAKE_Last'

--- a/aws/tests/utils/test_safe_object_from_dict.py
+++ b/aws/tests/utils/test_safe_object_from_dict.py
@@ -4,7 +4,7 @@ from aws.src.database.domain.dynamo_domain_objects import Tenure, HouseholdMembe
 from aws.src.utils.safe_object_from_dict import safe_object_from_dict
 
 
-def test_safe_object_from_dict_generates_tenure():
+def generates_tenure():
     """
     Returns a Tenure object with the correct values
     """
@@ -25,7 +25,7 @@ def test_safe_object_from_dict_generates_tenure():
     assert isinstance(tenure.householdMembers[0], HouseholdMember)
     assert tenure.householdMembers[0].fullName == 'FAKE_First FAKE_Last'
 
-def test_safe_object_from_dict_handles_undefined_fields():
+def handles_undefined_fields():
     """
     Not affected by undefined fields in outer and inner objects and still allows for inner conversion
     """

--- a/aws/tests/utils/test_safe_object_from_dict.py
+++ b/aws/tests/utils/test_safe_object_from_dict.py
@@ -4,7 +4,7 @@ from aws.src.database.domain.dynamo_domain_objects import Tenure, HouseholdMembe
 from aws.src.utils.safe_object_from_dict import safe_object_from_dict
 
 
-def test_generate_tenure_from_dict():
+def test_safe_object_from_dict_generates_tenure():
     """
     Test that safe_object_from_dict returns a Tenure object with the correct values
     """
@@ -17,6 +17,10 @@ def test_generate_tenure_from_dict():
 
     tenure = safe_object_from_dict(Tenure, eg_tenure)
 
+    # Does outer type conversion
+    assert isinstance(tenure, Tenure)
     assert tenure.id == '4c148ab7-a58b-a4c2-053a-03bc1684b559'
-    assert tenure.householdMembers[0].fullName == 'FAKE_First FAKE_Last'
+
+    # Does inner type conversion
     assert isinstance(tenure.householdMembers[0], HouseholdMember)
+    assert tenure.householdMembers[0].fullName == 'FAKE_First FAKE_Last'

--- a/aws/tests/utils/test_safe_object_from_dict.py
+++ b/aws/tests/utils/test_safe_object_from_dict.py
@@ -1,0 +1,22 @@
+from _decimal import Decimal
+
+from aws.src.database.domain.dynamo_domain_objects import Tenure, HouseholdMember
+from aws.src.utils.safe_object_from_dict import safe_object_from_dict
+
+
+def test_generate_tenure_from_dict():
+    """
+    Test that safe_object_from_dict returns a Tenure object with the correct values
+    """
+    eg_tenure = {
+        "id": '4c148ab7-a58b-a4c2-053a-03bc1684b559',
+        'householdMembers': [
+            {'fullName': 'FAKE_First FAKE_Last', 'isResponsible': True, 'dateOfBirth': '1900-03-02T00:00:00',
+             'personTenureType': 'Tenant', 'id': '713ac847-99fb-c771-5a72-55542a76dcc2', 'type': 'Person'}]
+    }
+
+    tenure = safe_object_from_dict(Tenure, eg_tenure)
+
+    assert tenure.id == '4c148ab7-a58b-a4c2-053a-03bc1684b559'
+    assert tenure.householdMembers[0].fullName == 'FAKE_First FAKE_Last'
+    assert isinstance(tenure.householdMembers[0], HouseholdMember)

--- a/aws/tests/utils/test_safe_object_from_dict.py
+++ b/aws/tests/utils/test_safe_object_from_dict.py
@@ -6,7 +6,7 @@ from aws.src.utils.safe_object_from_dict import safe_object_from_dict
 
 def test_safe_object_from_dict_generates_tenure():
     """
-    Test that safe_object_from_dict returns a Tenure object with the correct values
+    Returns a Tenure object with the correct values
     """
     eg_tenure = {
         "id": '4c148ab7-a58b-a4c2-053a-03bc1684b559',
@@ -24,3 +24,33 @@ def test_safe_object_from_dict_generates_tenure():
     # Does inner type conversion
     assert isinstance(tenure.householdMembers[0], HouseholdMember)
     assert tenure.householdMembers[0].fullName == 'FAKE_First FAKE_Last'
+
+def test_safe_object_from_dict_handles_undefined_fields():
+    """
+    Not affected by undefined fields in outer and inner objects and still allows for inner conversion
+    """
+    eg_tenure = {
+        "id": '4c148ab7-a58b-a4c2-053a-03bc1684b559',
+        "undefinedOuterField": "undefined",
+        'householdMembers': [
+            {'fullName': 'FAKE_First FAKE_Last', 'isResponsible': True, 'dateOfBirth': '1900-03-02T00:00:00',
+             'personTenureType': 'Tenant', 'id': '713ac847-99fb-c771-5a72-55542a76dcc2', 'type': 'Person',
+             'undefinedInnerField': 'undefined'
+            }]
+    }
+
+    tenure = safe_object_from_dict(Tenure, eg_tenure)
+
+    # Sets defined fields on outer object
+    assert hasattr(tenure, 'id')
+    assert hasattr(tenure, 'householdMembers')
+
+    # Does not set undefined fields on outer object
+    assert not hasattr(tenure, 'undefinedOuterField')
+
+    # Sets defined fields on inner object
+    assert hasattr(tenure.householdMembers[0], 'id')
+    assert hasattr(tenure.householdMembers[0], 'fullName')
+
+    # Does not set undefined fields on inner object
+    assert not hasattr(tenure.householdMembers[0], 'undefinedInnerField')


### PR DESCRIPTION
These updates should make it easier to generate domain objects from dynamodb queries. After fetching data from dynamodb it returns as a dictionary, then safe_object_from_dict can be called to convert it into the correct object type (asset / tenure / person) etc, which ensures type safety.

Can also be used in scripts that process CSVs to ensure type safety and completeness.