### PR TITLE
Charge adjustment tests

### DIFF
--- a/aws/src/database/rds/housing_finance/checks/heating_charge_adjustment/all_hca_tests.py
+++ b/aws/src/database/rds/housing_finance/checks/heating_charge_adjustment/all_hca_tests.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+
+from _decimal import Decimal
+
+from aws.src.database.rds.housing_finance.session_for_hfs import session_for_hfs
+from enums.enums import Stage
+from heating_charge_adjustment_for_propref import main_tests as heating_charge_adjustment_tests
+from udf_ResolveAdjustedChargeValue_test import main_tests as udf_tests
+
+ADJUSTABLE_PROPREF = input("Enter adjustable propref: ")
+EXCLUDED_PROPREF = input("Enter excluded propref: ")
+
+STAGE = Stage.HOUSING_DEVELOPMENT
+FIN_YEAR_START = datetime(2023, 4, 1)
+EFFECTIVE_DATE = datetime(2023, 6, 2)
+HEATING_TRANS_TYPE = 'DHE'
+ADJUSTMENT_FACTOR = Decimal(0.94)
+
+TEST_CHARGE_AMOUNT = Decimal(100.00)
+CUTOFF_DATE = datetime(2023, 6, 2)
+
+
+def main():
+    HfsSession = session_for_hfs(STAGE)
+    with HfsSession.begin() as session:
+        print("Running main tests...")
+        heating_charge_adjustment_tests(
+            session, ADJUSTABLE_PROPREF, EXCLUDED_PROPREF, FIN_YEAR_START, EFFECTIVE_DATE, ADJUSTMENT_FACTOR
+        )
+        udf_tests(session, ADJUSTABLE_PROPREF, EXCLUDED_PROPREF, TEST_CHARGE_AMOUNT, CUTOFF_DATE)
+        print("--------\nAll tests PASSED\n--------")
+
+
+if __name__ == '__main__':
+    main()

--- a/aws/src/database/rds/housing_finance/checks/heating_charge_adjustment/all_hca_tests.py
+++ b/aws/src/database/rds/housing_finance/checks/heating_charge_adjustment/all_hca_tests.py
@@ -17,7 +17,7 @@ HEATING_TRANS_TYPE = 'DHE'
 ADJUSTMENT_FACTOR = Decimal(0.94)
 
 TEST_CHARGE_AMOUNT = Decimal(100.00)
-CUTOFF_DATE = datetime(2023, 6, 2)
+ADJUSTMENT_EFFECTIVE_DATE = datetime(2023, 6, 2)
 
 
 def main():
@@ -27,7 +27,7 @@ def main():
         heating_charge_adjustment_tests(
             session, ADJUSTABLE_PROPREF, EXCLUDED_PROPREF, FIN_YEAR_START, EFFECTIVE_DATE, ADJUSTMENT_FACTOR
         )
-        udf_tests(session, ADJUSTABLE_PROPREF, EXCLUDED_PROPREF, TEST_CHARGE_AMOUNT, CUTOFF_DATE)
+        udf_tests(session, ADJUSTABLE_PROPREF, EXCLUDED_PROPREF, TEST_CHARGE_AMOUNT, ADJUSTMENT_EFFECTIVE_DATE)
         print("--------\nAll tests PASSED\n--------")
 
 

--- a/aws/src/database/rds/housing_finance/checks/heating_charge_adjustment/heating_charge_adjustment_for_propref.py
+++ b/aws/src/database/rds/housing_finance/checks/heating_charge_adjustment/heating_charge_adjustment_for_propref.py
@@ -3,15 +3,13 @@ from datetime import datetime
 from _decimal import Decimal
 
 from aws.src.database.rds.housing_finance.entities.Charge import Charge
-from aws.src.database.rds.housing_finance.entities.ChargesHistoryAdjustmentsExclusion import \
-    ChargesHistoryAdjustmentsExclusion
 from aws.src.database.rds.housing_finance.entities.ChargesHistoryEntity import ChargesHistoryEntity
 from aws.src.database.rds.housing_finance.entities.SSMiniTransaction import SSMiniTransaction
 from aws.src.database.rds.housing_finance.session_for_hfs import session_for_hfs
 from enums.enums import Stage
 
-ADJUSTED_PROPREF = input()
-EXCLUDED_PROPREF = input()
+ADJUSTABLE_PROPREF = input("Enter adjustable propref: ")
+EXCLUDED_PROPREF = input("Enter excluded propref: ")
 
 FIN_YEAR_START = datetime(2023, 4, 1)
 EFFECTIVE_DATE = datetime(2023, 6, 2)

--- a/aws/src/database/rds/housing_finance/checks/heating_charge_adjustment/heating_charge_adjustment_for_propref.py
+++ b/aws/src/database/rds/housing_finance/checks/heating_charge_adjustment/heating_charge_adjustment_for_propref.py
@@ -1,0 +1,88 @@
+from datetime import datetime
+
+from _decimal import Decimal
+
+from aws.src.database.rds.housing_finance.entities.Charge import Charge
+from aws.src.database.rds.housing_finance.entities.ChargesHistoryAdjustmentsExclusion import \
+    ChargesHistoryAdjustmentsExclusion
+from aws.src.database.rds.housing_finance.entities.ChargesHistoryEntity import ChargesHistoryEntity
+from aws.src.database.rds.housing_finance.entities.SSMiniTransaction import SSMiniTransaction
+from aws.src.database.rds.housing_finance.session_for_hfs import session_for_hfs
+from enums.enums import Stage
+
+ADJUSTED_PROPREF = input()
+EXCLUDED_PROPREF = input()
+
+FIN_YEAR_START = datetime(2023, 4, 1)
+EFFECTIVE_DATE = datetime(2023, 6, 2)
+HEATING_TRANS_TYPE = 'DHE'
+ADJUSTMENT_FACTOR = Decimal(0.94)
+
+
+def heating_charge_adjustment_test(
+        prop_ref: str, fin_year_start: datetime, effective_date: datetime, adjustment_factor: Decimal):
+    HfsSession = session_for_hfs(Stage.HOUSING_DEVELOPMENT)
+    with HfsSession.begin() as session:
+        # == Charges ==
+        charges = session.query(Charge) \
+            .where(
+            (Charge.PropertyRef == prop_ref) &
+            (Charge.ChargeType == HEATING_TRANS_TYPE) &
+            (Charge.Active == True)
+        ).all()
+        print("\n\n=== Charges ===")
+        for charge in charges:
+            print(charge)
+        base_amount = charges[0].Amount
+        print(f"base_amount: {base_amount}")
+
+        # == ChargesHistory ==
+        charges_history = session.query(ChargesHistoryEntity) \
+            .where(
+            (ChargesHistoryEntity.PropertyRef == prop_ref) &
+            (ChargesHistoryEntity.ChargeType == HEATING_TRANS_TYPE) &
+            (ChargesHistoryEntity.Date >= fin_year_start)
+        ).order_by(ChargesHistoryEntity.Date.desc()) \
+            .all()
+
+        print("\n\n=== ChargesHistory ===")
+        for charge in charges_history:
+            if charge.Date < effective_date:
+                print(f"\n{charge}")
+                expected_amount = base_amount
+                assert charge.Amount == expected_amount, \
+                    f"(BEFORE Eff Date) Charge amount incorrect: {charge.Amount} != {expected_amount}"
+                print(f"(BEFORE Eff Date) Charge amount correct: {charge.Amount} == {expected_amount}")
+            elif charge.Date >= effective_date:
+                print(f"\n{charge}")
+                expected_amount = round(base_amount * adjustment_factor, 2)
+                assert charge.Amount == expected_amount, \
+                    f"(AFTER Eff Date) Charge amount incorrect: {charge.Amount} != {expected_amount}"
+                print(f"(AFTER Eff Date) Charge amount correct: {base_amount} == {expected_amount}")
+
+        # == SSMiniTransaction ==
+        ssmini_transaction = session.query(SSMiniTransaction) \
+            .where(
+            (SSMiniTransaction.prop_ref == prop_ref) &
+            (SSMiniTransaction.trans_type == HEATING_TRANS_TYPE) &
+            (SSMiniTransaction.post_date >= fin_year_start)
+        ).order_by(SSMiniTransaction.post_date.desc())
+
+        print("\n\n=== SSMiniTransaction ===")
+        for transaction in ssmini_transaction:
+            print(f"\n{transaction}")
+            if transaction.post_date < effective_date:
+                expected_amount = base_amount
+                assert transaction.real_value == expected_amount, \
+                    f"(BEFORE Eff Date) Transaction amount incorrect: {transaction.real_value} != {expected_amount}"
+                print(f"(BEFORE Eff Date) Transaction amount correct: {base_amount} == {expected_amount}")
+            elif transaction.post_date >= effective_date:
+                expected_amount = round(base_amount * adjustment_factor, 2)
+                assert transaction.real_value == expected_amount, \
+                    f"(AFTER Eff Date) Transaction amount incorrect: {transaction.real_value} != {expected_amount}"
+                print(f"(AFTER Eff Date) Transaction amount correct: {base_amount} -> {expected_amount}")
+    print("--------\nTests PASSED\n--------")
+
+
+if __name__ == "__main__":
+    heating_charge_adjustment_test(EXCLUDED_PROPREF, FIN_YEAR_START, EFFECTIVE_DATE, ADJUSTMENT_FACTOR)

--- a/aws/src/database/rds/housing_finance/checks/heating_charge_adjustment/heating_charge_adjustment_for_propref.py
+++ b/aws/src/database/rds/housing_finance/checks/heating_charge_adjustment/heating_charge_adjustment_for_propref.py
@@ -27,7 +27,7 @@ def heating_charge_adjustment_test(
             .where(
             (Charge.PropertyRef == prop_ref) &
             (Charge.ChargeType == HEATING_TRANS_TYPE) &
-            (Charge.Active.is_(True))
+            (Charge.Active == True)
         ).all()
         print("\n\n=== Charges ===")
         for charge in charges:
@@ -82,5 +82,13 @@ def heating_charge_adjustment_test(
     print("--------\nTests PASSED\n--------")
 
 
+def main_tests():
+    # Should adjust for included propref
+    heating_charge_adjustment_test(ADJUSTABLE_PROPREF, FIN_YEAR_START, EFFECTIVE_DATE, ADJUSTMENT_FACTOR)
+
+    # Should not adjust for excluded propref
+    heating_charge_adjustment_test(EXCLUDED_PROPREF, FIN_YEAR_START, EFFECTIVE_DATE, Decimal(1.0))
+
+
 if __name__ == "__main__":
-    heating_charge_adjustment_test(EXCLUDED_PROPREF, FIN_YEAR_START, EFFECTIVE_DATE, ADJUSTMENT_FACTOR)
+    main_tests()

--- a/aws/src/database/rds/housing_finance/checks/heating_charge_adjustment/heating_charge_adjustment_for_propref.py
+++ b/aws/src/database/rds/housing_finance/checks/heating_charge_adjustment/heating_charge_adjustment_for_propref.py
@@ -11,6 +11,7 @@ from enums.enums import Stage
 ADJUSTABLE_PROPREF = input("Enter adjustable propref: ")
 EXCLUDED_PROPREF = input("Enter excluded propref: ")
 
+STAGE = Stage.HOUSING_DEVELOPMENT
 FIN_YEAR_START = datetime(2023, 4, 1)
 EFFECTIVE_DATE = datetime(2023, 6, 2)
 HEATING_TRANS_TYPE = 'DHE'
@@ -19,14 +20,14 @@ ADJUSTMENT_FACTOR = Decimal(0.94)
 
 def heating_charge_adjustment_test(
         prop_ref: str, fin_year_start: datetime, effective_date: datetime, adjustment_factor: Decimal):
-    HfsSession = session_for_hfs(Stage.HOUSING_DEVELOPMENT)
+    HfsSession = session_for_hfs(STAGE)
     with HfsSession.begin() as session:
         # == Charges ==
         charges = session.query(Charge) \
             .where(
             (Charge.PropertyRef == prop_ref) &
             (Charge.ChargeType == HEATING_TRANS_TYPE) &
-            (Charge.Active == True)
+            (Charge.Active.is_(True))
         ).all()
         print("\n\n=== Charges ===")
         for charge in charges:
@@ -40,8 +41,7 @@ def heating_charge_adjustment_test(
             (ChargesHistoryEntity.PropertyRef == prop_ref) &
             (ChargesHistoryEntity.ChargeType == HEATING_TRANS_TYPE) &
             (ChargesHistoryEntity.Date >= fin_year_start)
-        ).order_by(ChargesHistoryEntity.Date.desc()) \
-            .all()
+        ).order_by(ChargesHistoryEntity.Date.desc()).all()
 
         print("\n\n=== ChargesHistory ===")
         for charge in charges_history:

--- a/aws/src/database/rds/housing_finance/checks/heating_charge_adjustment/heating_charge_adjustment_for_propref.py
+++ b/aws/src/database/rds/housing_finance/checks/heating_charge_adjustment/heating_charge_adjustment_for_propref.py
@@ -1,70 +1,60 @@
 from datetime import datetime
 
 from _decimal import Decimal
+from sqlalchemy.orm import Session
 
 from aws.src.database.rds.housing_finance.entities.Charge import Charge
 from aws.src.database.rds.housing_finance.entities.ChargesHistoryEntity import ChargesHistoryEntity
 from aws.src.database.rds.housing_finance.entities.SSMiniTransaction import SSMiniTransaction
-from aws.src.database.rds.housing_finance.session_for_hfs import session_for_hfs
-from enums.enums import Stage
-
-ADJUSTABLE_PROPREF = input("Enter adjustable propref: ")
-EXCLUDED_PROPREF = input("Enter excluded propref: ")
-
-STAGE = Stage.HOUSING_DEVELOPMENT
-FIN_YEAR_START = datetime(2023, 4, 1)
-EFFECTIVE_DATE = datetime(2023, 6, 2)
-HEATING_TRANS_TYPE = 'DHE'
-ADJUSTMENT_FACTOR = Decimal(0.94)
 
 
 def heating_charge_adjustment_test(
-        prop_ref: str, fin_year_start: datetime, effective_date: datetime, adjustment_factor: Decimal):
-    HfsSession = session_for_hfs(STAGE)
-    with HfsSession.begin() as session:
-        # == Charges ==
-        charges = session.query(Charge) \
-            .where(
-            (Charge.PropertyRef == prop_ref) &
-            (Charge.ChargeType == HEATING_TRANS_TYPE) &
-            (Charge.Active == True)
-        ).all()
-        print("\n\n=== Charges ===")
-        for charge in charges:
-            print(charge)
-        base_amount = charges[0].Amount
-        print(f"base_amount: {base_amount}")
+        session: Session, prop_ref: str, fin_year_start: datetime,
+        effective_date: datetime, adjustment_factor: Decimal):
+    heating_trans_type = 'DHE'
 
-        # == ChargesHistory ==
-        charges_history = session.query(ChargesHistoryEntity) \
-            .where(
-            (ChargesHistoryEntity.PropertyRef == prop_ref) &
-            (ChargesHistoryEntity.ChargeType == HEATING_TRANS_TYPE) &
-            (ChargesHistoryEntity.Date >= fin_year_start)
-        ).order_by(ChargesHistoryEntity.Date.desc()).all()
+    # == Charges ==
+    charges = session.query(Charge) \
+        .where(
+        (Charge.PropertyRef == prop_ref) &
+        (Charge.ChargeType == heating_trans_type) &
+        (Charge.Active == True)
+    ).all()
+    print("\n\n=== Charges ===")
+    for charge in charges:
+        print(charge)
+    base_amount = charges[0].Amount
+    print(f"base_amount: {base_amount}")
 
-        print("\n\n=== ChargesHistory ===")
-        for charge in charges_history:
-            if charge.Date < effective_date:
-                print(f"\n{charge}")
-                expected_amount = base_amount
-                assert charge.Amount == expected_amount, \
-                    f"(BEFORE Eff Date) Charge amount incorrect: {charge.Amount} != {expected_amount}"
-                print(f"(BEFORE Eff Date) Charge amount correct: {charge.Amount} == {expected_amount}")
-            elif charge.Date >= effective_date:
-                print(f"\n{charge}")
-                expected_amount = round(base_amount * adjustment_factor, 2)
-                assert charge.Amount == expected_amount, \
-                    f"(AFTER Eff Date) Charge amount incorrect: {charge.Amount} != {expected_amount}"
-                print(f"(AFTER Eff Date) Charge amount correct: {base_amount} == {expected_amount}")
+    # == ChargesHistory ==
+    charges_history = session.query(ChargesHistoryEntity) \
+        .where(
+        (ChargesHistoryEntity.PropertyRef == prop_ref) &
+        (ChargesHistoryEntity.ChargeType == heating_trans_type) &
+        (ChargesHistoryEntity.Date >= fin_year_start)
+    ).order_by(ChargesHistoryEntity.Date.desc()).all()
 
-        # == SSMiniTransaction ==
-        ssmini_transaction = session.query(SSMiniTransaction) \
-            .where(
-            (SSMiniTransaction.prop_ref == prop_ref) &
-            (SSMiniTransaction.trans_type == HEATING_TRANS_TYPE) &
-            (SSMiniTransaction.post_date >= fin_year_start)
-        ).order_by(SSMiniTransaction.post_date.desc())
+    # == SSMiniTransaction ==
+    ssmini_transaction = session.query(SSMiniTransaction) \
+        .where(
+        (SSMiniTransaction.prop_ref == prop_ref) &
+        (SSMiniTransaction.trans_type == heating_trans_type) &
+        (SSMiniTransaction.post_date >= fin_year_start)
+    ).order_by(SSMiniTransaction.post_date.desc()).all()
+
+    print("\n\n=== ChargesHistory ===")
+    for charge in charges_history:
+        if charge.Date < effective_date:
+            print(f"\n{charge}")
+            expected_amount = base_amount
+            assert charge.Amount == expected_amount, \
+                f"(BEFORE Eff Date) Charge amount incorrect: {charge.Amount} != {expected_amount}"
+
+        elif charge.Date >= effective_date:
+            print(f"\n{charge}")
+            expected_amount = round(base_amount * adjustment_factor, 2)
+            assert charge.Amount == expected_amount, \
+                f"(AFTER Eff Date) Charge amount incorrect: {charge.Amount} != {expected_amount}"
 
         print("\n\n=== SSMiniTransaction ===")
         for transaction in ssmini_transaction:
@@ -79,16 +69,15 @@ def heating_charge_adjustment_test(
                 assert transaction.real_value == expected_amount, \
                     f"(AFTER Eff Date) Transaction amount incorrect: {transaction.real_value} != {expected_amount}"
                 print(f"(AFTER Eff Date) Transaction amount correct: {base_amount} -> {expected_amount}")
-    print("--------\nTests PASSED\n--------")
 
 
-def main_tests():
+def main_tests(
+        session: Session, adjustable_propref: str, excluded_propref: str, fin_year_start: datetime,
+        effective_date: datetime, adjustment_factor: Decimal):
+    print("Heating charge adjustment tests...")
     # Should adjust for included propref
-    heating_charge_adjustment_test(ADJUSTABLE_PROPREF, FIN_YEAR_START, EFFECTIVE_DATE, ADJUSTMENT_FACTOR)
+    heating_charge_adjustment_test(session, adjustable_propref, fin_year_start, effective_date, adjustment_factor)
 
     # Should not adjust for excluded propref
-    heating_charge_adjustment_test(EXCLUDED_PROPREF, FIN_YEAR_START, EFFECTIVE_DATE, Decimal(1.0))
-
-
-if __name__ == "__main__":
-    main_tests()
+    heating_charge_adjustment_test(session, excluded_propref, fin_year_start, effective_date, Decimal(1.0))
+    print("--------\nHeating Charge Adjustment PASSED\n--------")

--- a/aws/src/database/rds/housing_finance/checks/heating_charge_adjustment/udf_ResolveAdjustedChargeValue_test.py
+++ b/aws/src/database/rds/housing_finance/checks/heating_charge_adjustment/udf_ResolveAdjustedChargeValue_test.py
@@ -68,8 +68,12 @@ def check_if_propref_gets_adjusted(session: Session, prop_ref: str, should_adjus
         f"FAIL Charge amount is not as expected: {result} != {expected_amount}"
 
 
-if __name__ == '__main__':
+def main_tests():
     HfsSession = session_for_hfs(Stage.HOUSING_DEVELOPMENT)
     with HfsSession.begin() as sess:
         check_if_propref_gets_adjusted(sess, ADJUSTABLE_PROPREF, should_adjust=True)
         check_if_propref_gets_adjusted(sess, EXCLUDED_PROPREF, should_adjust=False)
+
+
+if __name__ == '__main__':
+    main_tests()

--- a/aws/src/database/rds/housing_finance/checks/heating_charge_adjustment/udf_ResolveAdjustedChargeValue_test.py
+++ b/aws/src/database/rds/housing_finance/checks/heating_charge_adjustment/udf_ResolveAdjustedChargeValue_test.py
@@ -42,20 +42,20 @@ def get_result(session: Session, prop_ref: str, charge_date: datetime, test_char
 
 def check_if_propref_gets_adjusted(
         session: Session, prop_ref: str, should_adjust: bool,
-        test_charge_amount: Decimal, cutoff_date: datetime):
+        test_charge_amount: Decimal, adjustment_effective_date: datetime):
     # Does not modify charges before cutoff date
-    past_charge_date = cutoff_date - timedelta(days=1)
+    past_charge_date = adjustment_effective_date - timedelta(days=1)
     result = get_result(session, prop_ref, past_charge_date, test_charge_amount)
     expected_amount = test_charge_amount
     assert result == expected_amount, \
-        f"FAIL Modified charge before cutoff date {cutoff_date}: {result} != {expected_amount}"
+        f"FAIL Modified charge before cutoff date {adjustment_effective_date}: {result} != {expected_amount}"
 
     # Adjusts charges after cutoff date (if expected)
     if should_adjust:
         expected_amount = round(test_charge_amount * Decimal(0.94), 2)
     else:
         expected_amount = test_charge_amount
-    future_charge_date = cutoff_date + timedelta(days=1)
+    future_charge_date = adjustment_effective_date + timedelta(days=1)
     result = get_result(session, prop_ref, future_charge_date, test_charge_amount)
 
     assert result == expected_amount, \
@@ -64,8 +64,8 @@ def check_if_propref_gets_adjusted(
 
 def main_tests(
         sess: Session, adjustable_propref: str, excluded_propref: str,
-        test_charge_amount: Decimal, cutoff_date: datetime):
+        test_charge_amount: Decimal, adjustment_effective_date: datetime):
     print("Running udf_ResolveAdjustedChargeValue tests...")
-    check_if_propref_gets_adjusted(sess, adjustable_propref, True, test_charge_amount, cutoff_date)
-    check_if_propref_gets_adjusted(sess, excluded_propref, False, test_charge_amount, cutoff_date)
+    check_if_propref_gets_adjusted(sess, adjustable_propref, True, test_charge_amount, adjustment_effective_date)
+    check_if_propref_gets_adjusted(sess, excluded_propref, False, test_charge_amount, adjustment_effective_date)
     print("--------\nudf_ResolveAdjustedChargeValue tests PASSED\n--------")

--- a/aws/src/database/rds/housing_finance/checks/heating_charge_adjustment/udf_ResolveAdjustedChargeValue_test.py
+++ b/aws/src/database/rds/housing_finance/checks/heating_charge_adjustment/udf_ResolveAdjustedChargeValue_test.py
@@ -8,6 +8,8 @@ from sqlalchemy.orm import Session
 from aws.src.database.rds.housing_finance.session_for_hfs import session_for_hfs
 from enums.enums import Stage
 
+STAGE = Stage.HOUSING_DEVELOPMENT
+
 ADJUSTABLE_PROPREF = input("Enter adjustable propref: ")
 EXCLUDED_PROPREF = input("Enter excluded propref: ")
 CUTOFF_DATE = datetime(2023, 6, 2)
@@ -69,7 +71,7 @@ def check_if_propref_gets_adjusted(session: Session, prop_ref: str, should_adjus
 
 
 def main_tests():
-    HfsSession = session_for_hfs(Stage.HOUSING_DEVELOPMENT)
+    HfsSession = session_for_hfs(STAGE)
     with HfsSession.begin() as sess:
         check_if_propref_gets_adjusted(sess, ADJUSTABLE_PROPREF, should_adjust=True)
         check_if_propref_gets_adjusted(sess, EXCLUDED_PROPREF, should_adjust=False)

--- a/aws/src/database/rds/housing_finance/checks/heating_charge_adjustment/udf_ResolveAdjustedChargeValue_test.py
+++ b/aws/src/database/rds/housing_finance/checks/heating_charge_adjustment/udf_ResolveAdjustedChargeValue_test.py
@@ -1,0 +1,88 @@
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+from _decimal import Decimal
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from aws.src.database.rds.housing_finance.session_for_hfs import session_for_hfs
+from enums.enums import Stage
+
+ADJUSTED_PROPREF = input()
+EXCLUDED_PROPREF = input()
+CUTOFF_DATE = datetime(2023, 6, 2)
+
+TEST_CHARGE_AMOUNT = Decimal(100.00)
+
+
+@dataclass
+class FuncArgs:
+    property_ref: str
+    charge_amount: Decimal
+    charge_type: str
+    charge_date: datetime
+    days_diff: int = 7
+
+
+def get_result(session: Session, prop_ref: str, charge_date: datetime) -> Decimal:
+    test_charge = FuncArgs(
+        property_ref=prop_ref,
+        charge_amount=TEST_CHARGE_AMOUNT,
+        charge_type='DHE',
+        charge_date=charge_date,
+        days_diff=7
+    )
+    query = text(
+        f'SELECT dbo.udf_ResolveAdjustedChargeValue(:property_ref, :charge_amount, :charge_type, :charge_date, :days_diff)')
+
+    # Call user defined function with test data
+    result = session.execute(query, {
+        'property_ref': test_charge.property_ref,
+        'charge_amount': test_charge.charge_amount,
+        'charge_type': test_charge.charge_type,
+        'charge_date': test_charge.charge_date,
+        'days_diff': test_charge.days_diff
+    }).fetchone()[0]
+    # Round to 2 decimal places
+    result: Decimal = result.quantize(Decimal('.01'))
+    return result
+
+
+def does_not_modify_charges_before_cutoff_date(session: Session, prop_ref: str):
+    past_charge_date = CUTOFF_DATE - timedelta(days=1)
+    result = get_result(session, prop_ref, past_charge_date)
+    expected_amount = TEST_CHARGE_AMOUNT
+
+    print("\nDoes not modify charges before cutoff date")
+    assert result == expected_amount, \
+        f"FAIL Charge amount is not as expected: {result} != {expected_amount}"
+    print(f"PASS {result} -> {expected_amount}")
+
+
+def adjusts_charges_after_cutoff_date(session: Session, prop_ref: str):
+    # Call user defined function with test data
+    future_charge_date = CUTOFF_DATE + timedelta(days=1)
+    result = get_result(session, prop_ref, future_charge_date)
+    result = round(result, 2)
+    expected_amount = round(TEST_CHARGE_AMOUNT * Decimal(0.94), 2)
+    print("\nAdjusts charges after cutoff date")
+    assert result == expected_amount, \
+        f"FAIL Charge amount is not as expected: {result} != {expected_amount}"
+    print(f"PASS {result} -> {expected_amount}")
+
+
+def does_not_modify_excluded_propref(session: Session, prop_ref: str):
+    result = get_result(session, prop_ref, CUTOFF_DATE + timedelta(days=1))
+    expected_amount = TEST_CHARGE_AMOUNT
+    print("\nDoes not modify excluded propref")
+    assert result == expected_amount, \
+        f"FAIL Charge amount is not as expected: {result} != {expected_amount}"
+    print(f"PASS {result} -> {expected_amount}")
+
+
+if __name__ == '__main__':
+    HfsSession = session_for_hfs(Stage.HOUSING_DEVELOPMENT)
+    with HfsSession.begin() as sess:
+        does_not_modify_charges_before_cutoff_date(sess, ADJUSTED_PROPREF)
+        adjusts_charges_after_cutoff_date(sess, ADJUSTED_PROPREF)
+        does_not_modify_excluded_propref(sess, EXCLUDED_PROPREF)

--- a/aws/src/database/rds/housing_finance/entities/Base.py
+++ b/aws/src/database/rds/housing_finance/entities/Base.py
@@ -1,0 +1,5 @@
+from sqlalchemy.orm import MappedAsDataclass, DeclarativeBase
+
+
+class Base(MappedAsDataclass, DeclarativeBase):
+    pass

--- a/aws/src/database/rds/housing_finance/entities/Charge.py
+++ b/aws/src/database/rds/housing_finance/entities/Charge.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass, asdict
+
+from sqlalchemy import String, INT, DateTime, DECIMAL, Boolean
+from sqlalchemy.orm import Mapped, mapped_column
+from aws.src.database.rds.housing_finance.entities.Base import Base
+
+
+@dataclass
+class Charge(Base):
+    __tablename__ = "Charges"
+    __table_args__ = {"schema": "dbo"}
+
+    Id: Mapped[int] = mapped_column(primary_key=True)
+    RentGroup: Mapped[str] = mapped_column(String(3))
+    PropertyRef: Mapped[str] = mapped_column(String(255))
+    ChargePeriod: Mapped[str] = mapped_column(String(255))
+    ChargeType: Mapped[str] = mapped_column(String(3))
+    Amount: Mapped[float] = mapped_column(DECIMAL)
+    Active: Mapped[bool] = mapped_column(Boolean)
+    TimeStamp: Mapped[str] = mapped_column(DateTime)
+    Year: Mapped[int] = mapped_column(INT)
+
+    to_dict = asdict
+
+    def __repr__(self) -> str:
+        return f"Charge(id={self.Id}, ChargeType={self.ChargeType}, " \
+               f"Amount={self.Amount!r} PropertyRef={self.PropertyRef})"

--- a/aws/src/database/rds/housing_finance/entities/ChargesHistoryAdjustment.py
+++ b/aws/src/database/rds/housing_finance/entities/ChargesHistoryAdjustment.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass, asdict
+
+from sqlalchemy import String, INT, DateTime, DECIMAL, Boolean
+from sqlalchemy.orm import Mapped, mapped_column
+from aws.src.database.rds.housing_finance.entities.Base import Base
+
+
+@dataclass
+class ChargesHistoryAdjustment(Base):
+    __tablename__ = "ChargesHistoryAdjustments"
+    __table_args__ = {"schema": "dbo"}
+
+    Id: Mapped[int] = mapped_column(primary_key=True)
+    StartDate: Mapped[DateTime] = mapped_column(DateTime)
+    EndDate: Mapped[DateTime] = mapped_column(DateTime)
+    ChargeType: Mapped[str] = mapped_column(String(3))
+    AdjustmentFactor: Mapped[DECIMAL] = mapped_column(DECIMAL(5, 4))
+    Description: Mapped[str] = mapped_column(String(255))
+    ExclusionSetRef: Mapped[int] = mapped_column(INT)
+
+    to_dict = asdict
+
+    def __repr__(self) -> str:
+        return f"ChargesHistoryAdjustmentsExclusion(" \
+               f"Id={self.Id}, ExSet={self.ExclusionSetRef}, SD={self.StartDate}, ED={self.EndDate}"

--- a/aws/src/database/rds/housing_finance/entities/ChargesHistoryAdjustmentsExclusion.py
+++ b/aws/src/database/rds/housing_finance/entities/ChargesHistoryAdjustmentsExclusion.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass, asdict
+
+from sqlalchemy import String, INT, DateTime, DECIMAL, Boolean
+from sqlalchemy.orm import Mapped, mapped_column
+from aws.src.database.rds.housing_finance.entities.Base import Base
+
+
+@dataclass
+class ChargesHistoryAdjustmentsExclusion(Base):
+    __tablename__ = "ChargesHistoryAdjustmentsExclusion"
+    __table_args__ = {"schema": "dbo"}
+
+    Id: Mapped[int] = mapped_column(primary_key=True)
+    ExclusionSetRef: Mapped[int] = mapped_column(INT)
+    PropertyRef: Mapped[str] = mapped_column(String(12))
+
+    to_dict = asdict
+
+    def __repr__(self) -> str:
+        return f"CHA_Exclusion(id={self.Id}, ExclusionSetRef={self.ExclusionSetRef}, PropertyRef={self.PropertyRef})"

--- a/aws/src/database/rds/housing_finance/entities/ChargesHistoryEntity.py
+++ b/aws/src/database/rds/housing_finance/entities/ChargesHistoryEntity.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass, asdict
+from datetime import datetime
+
+from sqlalchemy import String, INT, DateTime, DECIMAL, Boolean
+from sqlalchemy.orm import Mapped, mapped_column
+from aws.src.database.rds.housing_finance.entities.Base import Base
+
+
+@dataclass
+class ChargesHistoryEntity(Base):
+    __tablename__ = "ChargesHistory"
+    __table_args__ = {"schema": "dbo"}
+
+    Id: Mapped[int] = mapped_column(primary_key=True)
+    TenancyAgreementRef: Mapped[str] = mapped_column(String(255))
+    PropertyRef: Mapped[str] = mapped_column(String(255))
+    ChargePeriod: Mapped[str] = mapped_column(String(255))
+    Date: Mapped[datetime] = mapped_column(DateTime)
+    IsRead: Mapped[bool] = mapped_column(Boolean)
+    ChargesId: Mapped[int] = mapped_column(INT)
+    ChargeType: Mapped[str] = mapped_column(String(3))
+    Amount: Mapped[float] = mapped_column(DECIMAL)
+    TimeStamp: Mapped[str] = mapped_column(DateTime)
+    FirstWeekAdjustment: Mapped[bool] = mapped_column(Boolean)
+    LastWeekAdjustment: Mapped[bool] = mapped_column(Boolean)
+
+    to_dict = asdict
+
+    def __repr__(self) -> str:
+        return f"ChargesHistoryEntity(id={self.Id}, ChargeType={self.ChargeType}, " \
+               f"Amount={self.Amount!r}, Date={self.Date.date()})"

--- a/aws/src/database/rds/housing_finance/entities/GoogleFileSetting.py
+++ b/aws/src/database/rds/housing_finance/entities/GoogleFileSetting.py
@@ -1,11 +1,8 @@
 from dataclasses import dataclass, asdict
 
 from sqlalchemy import String, INT, DateTime
-from sqlalchemy.orm import DeclarativeBase, MappedAsDataclass, Mapped, mapped_column
-
-
-class Base(MappedAsDataclass, DeclarativeBase):
-    pass
+from sqlalchemy.orm import Mapped, mapped_column
+from aws.src.database.rds.housing_finance.entities.Base import Base
 
 
 @dataclass

--- a/aws/src/database/rds/housing_finance/entities/SSMiniTransaction.py
+++ b/aws/src/database/rds/housing_finance/entities/SSMiniTransaction.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass, asdict
+
+from sqlalchemy import String, INT, DateTime, DECIMAL, Boolean
+from sqlalchemy.orm import Mapped, mapped_column
+from aws.src.database.rds.housing_finance.entities.Base import Base
+
+
+@dataclass
+class SSMiniTransaction(Base):
+    __tablename__ = "SSMiniTransaction"
+    __table_args__ = {"schema": "dbo"}
+
+    tag_ref: Mapped[str] = mapped_column(String(11))
+    prop_ref: Mapped[str] = mapped_column(String(12))
+    rentgroup: Mapped[str] = mapped_column(String(3))
+    post_year: Mapped[int] = mapped_column(INT)
+    post_prdno: Mapped[float] = mapped_column(DECIMAL(3))
+    tenure: Mapped[str] = mapped_column(String(3))
+    trans_type: Mapped[str] = mapped_column(String(3))
+    trans_src: Mapped[str] = mapped_column(String(3))
+    real_value: Mapped[float] = mapped_column(DECIMAL(9, 2))
+    post_date: Mapped[str] = mapped_column(DateTime)
+    trans_ref: Mapped[str] = mapped_column(String(12))
+    origin: Mapped[str] = mapped_column(String(255), primary_key=True)
+    origin_desc: Mapped[str] = mapped_column(String(255))
+
+    to_dict = asdict
+
+    def __repr__(self) -> str:
+        return f"ChargesHistoryEntity(origin={self.origin}, trans_type={self.trans_type}, real_value={self.real_value!r}, post_date={self.post_date})"

--- a/aws/src/database/rds/housing_finance/entities/SSMiniTransaction.py
+++ b/aws/src/database/rds/housing_finance/entities/SSMiniTransaction.py
@@ -27,4 +27,4 @@ class SSMiniTransaction(Base):
     to_dict = asdict
 
     def __repr__(self) -> str:
-        return f"ChargesHistoryEntity(origin={self.origin}, trans_type={self.trans_type}, real_value={self.real_value!r}, post_date={self.post_date})"
+        return f"SSMiniTransaction(origin={self.origin}, trans_type={self.trans_type}, real_value={self.real_value!r}, post_date={self.post_date})"

--- a/aws/src/database/rds/housing_finance/session_for_hfs.py
+++ b/aws/src/database/rds/housing_finance/session_for_hfs.py
@@ -5,7 +5,8 @@ Note: Ensure to install unixodbc to be able to use pyodbc
 import pyodbc
 from sqlalchemy import create_engine
 
-from aws.src.database.rds.housing_finance.entities.GoogleFileSetting import Base as HousingFinanceBase
+from aws.src.database.rds.housing_finance.entities.GoogleFileSetting import Base as HousingFinanceBase, \
+    GoogleFileSetting
 from mypy_boto3_ssm import SSMClient
 from sqlalchemy.orm import sessionmaker, Session as SA_Session
 
@@ -48,3 +49,7 @@ if __name__ == "__main__":
     """
     Example usage
     """
+    HfsSession = session_for_hfs(Stage.HOUSING_STAGING)
+    with HfsSession.begin() as session:
+        res = session.query(GoogleFileSetting).where(GoogleFileSetting.Label == "ChargesOLD").all()
+        print(res[0].GoogleIdentifier)

--- a/aws/src/database/rds/housing_finance/session_for_hfs.py
+++ b/aws/src/database/rds/housing_finance/session_for_hfs.py
@@ -10,11 +10,10 @@ from mypy_boto3_ssm import SSMClient
 from sqlalchemy.orm import sessionmaker, Session as SA_Session
 
 from aws.src.authentication.generate_aws_resource import generate_aws_service
-from aws.src.database.rds.housing_finance.entities.GoogleFileSetting import GoogleFileSetting
 from enums.enums import Stage
 
 
-def session_for_hfs(stage: Stage, expire_on_commit=True, local_port=1433) -> sessionmaker[SA_Session]:
+def session_for_hfs(stage: Stage, expire_on_commit=True, local_port=1433, logging=False) -> sessionmaker[SA_Session]:
     """
     Connect to cautionary alerts database
     :param stage: Stage to connect to
@@ -37,7 +36,7 @@ def session_for_hfs(stage: Stage, expire_on_commit=True, local_port=1433) -> ses
         raise IndexError("No ODBC Driver 17 for SQL Server found. Please install the driver and try again.")
 
     connection_string = f"DRIVER={driver};SERVER=127.0.0.1,{local_port};DATABASE=sow2b;UID={username};PWD={password}"
-    engine = create_engine("mssql+pyodbc://", creator=lambda: pyodbc.connect(connection_string), echo=True)
+    engine = create_engine("mssql+pyodbc://", creator=lambda: pyodbc.connect(connection_string), echo=logging)
     HousingFinanceBase.metadata.create_all(bind=engine)
 
     Session = sessionmaker(bind=engine, expire_on_commit=expire_on_commit)
@@ -49,7 +48,3 @@ if __name__ == "__main__":
     """
     Example usage
     """
-    HfsSession = session_for_hfs(Stage.HOUSING_STAGING)
-    with HfsSession.begin() as session:
-        res = session.query(GoogleFileSetting).where(GoogleFileSetting.Label == "ChargesOLD").all()
-        print(res[0].GoogleIdentifier)


### PR DESCRIPTION
Tests for a given property ref having heating charges adjusted, or having its adjustment excluded.
Also includes unit tests for the `udf_ResolveAdjustedChargeValue` function

Added table mappers for:
- Charges
- ChargesHistory
- SSMiniTransaction
- ChargesHistoryAdjustment
- ChargesHistoryAdjustmentExclusion

Disabled database logging by default and added function arg (was far too busy)

Added check scripts to validate heating charge adjustments & exclusions by property reference number