### PR TITLE
Asset patches schema change

### DIFF
--- a/aws/src/authentication/generate_aws_resource.py
+++ b/aws/src/authentication/generate_aws_resource.py
@@ -73,4 +73,4 @@ def generate_aws_service(service_name: str, stage: Stage) -> Any:
 
 if __name__ == "__main__":
     # Example usage + For testing
-    generate_aws_service("dynamodb", Stage.BASE_STAGING, "resource")
+    generate_aws_service("dynamodb", Stage.BASE_STAGING)

--- a/aws/src/authentication/generate_aws_resource.py
+++ b/aws/src/authentication/generate_aws_resource.py
@@ -40,7 +40,7 @@ def get_session_for_stage(stage: Stage | str) -> Session:
                   f"aws sso login --profile {stage_profile}; || - Run to refresh.\n"
                   f"If you have a {stage_profile} AWS SSO profile, hit enter to run this command and log in:")
             subprocess.Popen(["aws", "sso", "login", "--profile", stage_profile]).wait()
-            input("\nHit enter to try running the script again again")
+            input("\nHit enter to try running the script again")
         except botocore.exceptions.NoRegionError:
             # Thrown when there is no region configured for the profile
             input(f"\nNo region configured for profile {stage_profile}.\n"
@@ -49,32 +49,25 @@ def get_session_for_stage(stage: Stage | str) -> Session:
     return session
 
 
-def generate_aws_service(service_name: str, stage: Stage, service_type="resource") -> Any:
+def generate_aws_service(service_name: str, stage: Stage) -> Any:
     """
     :param service_name: The name of the service to get, e.g. "dynamodb"
     :param stage: The stage to get credentials for
-    :param service_type: The type of service to get, either "resource" or "client"
     :return: The service object
     """
-
     session: Session = get_session_for_stage(stage)
-    match service_type:
-        case "resource":
-            # Add to these as needed
-            valid_services = ["dynamodb"]
-            if service_name not in valid_services:
-                raise ValueError(f"Service name must be one of {valid_services}")
-            # noinspection PyTypeChecker
-            service: ServiceResource = session.resource(service_name)
-        case "client":
-            # Add to these as needed
-            valid_services = ["ssm", "rds", "es", "ec2", "opensearch"]
-            if service_name not in valid_services:
-                raise ValueError(f"Service name must be one of {valid_services}")
-            # noinspection PyTypeChecker
-            service: ServiceResource = session.client(service_name)
-        case _:
-            raise ValueError(f"Type must be one of ['resource', 'client']")
+    service_name = service_name.lower().strip()
+
+    # Info on resources: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/resources.html
+    # Info on clients: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/clients.html
+    valid_resources = ["dynamodb"]
+    valid_clients = ["ssm", "rds", "es", "opensearch"]
+    if service_name in valid_resources:
+        service: ServiceResource = session.resource(service_name)
+    elif service_name in valid_clients:
+        service: ServiceResource = session.client(service_name)
+    else:
+        raise ValueError(f"Valid service names are {valid_resources + valid_clients}")
     return service
 
 

--- a/aws/src/database/domain/dynamo_domain_objects.py
+++ b/aws/src/database/domain/dynamo_domain_objects.py
@@ -212,6 +212,8 @@ class AssetAddress:
 @dataclass
 class Asset:
     id: str
+    areaId: str | None
+    patchId: str | None
     assetAddress: AssetAddress | None
     assetCharacteristics: dict | None
     assetId: str | None
@@ -219,7 +221,6 @@ class Asset:
     assetManagement: dict | None
     assetType: str | None
     isActive: Decimal | None
-    patches: list[Patch]
     rootAsset: str | None
     tenure: AssetTenure | None
     parentAssetIds: str | None
@@ -231,8 +232,7 @@ class Asset:
 
         self.tenure = AssetTenure.from_data(self.tenure)
         self.assetAddress = AssetAddress.from_data(self.assetAddress)
-        if not all(isinstance(patch, Patch) for patch in self.patches):
-            self.patches = [Patch.from_data(patch) for patch in self.patches]
+        
 
     @classmethod
     def from_data(cls, data: dict):

--- a/aws/src/database/domain/dynamo_domain_objects.py
+++ b/aws/src/database/domain/dynamo_domain_objects.py
@@ -192,7 +192,7 @@ class AssetTenure:
     @classmethod
     def from_data(cls, data: dict):
         return _dataclass_from_data(cls, data)
-    
+
 
 @dataclass
 class AssetAddress:
@@ -220,19 +220,16 @@ class Asset:
     assetLocation: dict | None
     assetManagement: dict | None
     assetType: str | None
-    isActive: Decimal | None
+    isActive: int | None
     rootAsset: str | None
     tenure: AssetTenure | None
     parentAssetIds: str | None
-    versionNumber: Decimal | None
+    versionNumber: int | None
 
     def __post_init__(self):
-        if self.patches is None:
-            self.patches = []
-
         self.tenure = AssetTenure.from_data(self.tenure)
         self.assetAddress = AssetAddress.from_data(self.assetAddress)
-        
+
 
     @classmethod
     def from_data(cls, data: dict):

--- a/aws/src/database/dynamodb/scripts/asset_table/get_assets_add_patchId_areaId.py
+++ b/aws/src/database/dynamodb/scripts/asset_table/get_assets_add_patchId_areaId.py
@@ -26,21 +26,22 @@ from utils.confirm import confirm
 class Config:
     TABLE_NAME = "Assets"
     LOGGER = Logger()
-    STAGE = Stage.HOUSING_STAGING
+    STAGE = Stage.HOUSING_DEVELOPMENT
     if Path(__file__).parent.name == "mtfh-scripts":
         INPUT_FILE = "aws/src/database/dynamodb/scripts/asset_table/input/assetsStaging.json"
         PROCESSED_IDS_FILE = "aws/src/database/dynamodb/scripts/asset_table/output/processed_ids.csv"
     else:
-        INPUT_FILE = "input/assetsStaging.json"
+        INPUT_FILE = "input/assetsDev.json"
         PROCESSED_IDS_FILE = "output/processed_ids.csv"
-    ASSETS_PER_SECOND = 8
+    ASSETS_PER_SECOND = 8 / 1.5
     LIMIT = False  # Set to False when ready to run on all assets
 
 
 def add_processed_id(asset_pk: str, success: bool, reason: str = ""):
-    print(f"Processed asset {asset_pk}")
+    message = f"{asset_pk}, {success}, {reason}"
+    Config.LOGGER.log(message)
     with open(Config.PROCESSED_IDS_FILE, "a") as f:
-        f.write(f"{asset_pk}, {success}, {reason}\n")
+        f.write("\n" + message)
 
 
 def load_assets(file_path: str) -> list[dict]:
@@ -74,26 +75,19 @@ def change_asset_schema(raw_asset: dict) -> dict | None:
         - Sets patchId and areaId attributes
     """
     if not raw_asset.get("rootAsset"):
-        Config.LOGGER.log(f"Asset has no root asset, {raw_asset['id']}, skipping")
         add_processed_id(raw_asset["id"], False, "Has no root asset - required field")
         return None
     if raw_asset.get("patches") in [None, []]:
-        Config.LOGGER.log(f"Asset has no patches assigned, {raw_asset['id']}, skipping")
-        add_processed_id(raw_asset["id"], False, "No patches assigned")
+        add_processed_id(raw_asset["id"], False, f"No patches assigned: {raw_asset.get('patches')}")
         return None
     try:
-        if len(raw_asset["patches"]) > 1 and Config.STAGE == Stage.HOUSING_PRODUCTION:
-            Config.LOGGER.log(f"Prod Asset has more than one patch assigned to it, {raw_asset['id']}, skipping")
-            return None
-
         patches: list[dict] = [patch for patch in raw_asset["patches"] if patch.get("patchType") == "patch"]
         patch = patches[0] if patches else None
-        if patch:
-            raw_asset["patchId"] = patch["id"] if patch.get("id") else None
-            raw_asset["areaId"] = patch["parentId"] if patch.get("parentId") else None
-        else:
+        if patch is None:
             Config.LOGGER.log(f"Asset has no patch assigned, {raw_asset['id']}, skipping")
             return None
+        raw_asset["patchId"] = patch["id"] if patch.get("id") else None
+        raw_asset["areaId"] = patch["parentId"] if patch.get("parentId") else None
         raw_asset.pop("patches", None)
         return raw_asset
     except Exception as e:
@@ -102,13 +96,12 @@ def change_asset_schema(raw_asset: dict) -> dict | None:
         return None
 
 
-def update_assets(asset_table: Table, updated_assets: list[Asset]) -> int:
+def update_assets(asset_table: Table, updated_assets: list[Asset]):
     """
     update the asset record that are already assigned to a patch to have areaId and patchId and remove patches
     """
     delay_per_asset = round(1 / Config.ASSETS_PER_SECOND, 2)
     print(f"Processing {Config.ASSETS_PER_SECOND} assets per second with a delay of {delay_per_asset} seconds per asset")
-    update_count = 0
     progress_bar = ProgressBar(len(updated_assets))
     for i, asset_item in enumerate(updated_assets):
         if i % 100 == 0:
@@ -116,13 +109,12 @@ def update_assets(asset_table: Table, updated_assets: list[Asset]) -> int:
         try:
             asset_item.versionNumber = asset_item.versionNumber + 1 if asset_item.versionNumber else 0
             asset_table.put_item(Item=asdict(asset_item))
-            update_count += 1
             add_processed_id(asset_item.id, True)
             time.sleep(delay_per_asset)
         except Exception as e:
             Config.LOGGER.log(f"Failed to update asset {asset_item.id} with error {e}")
             add_processed_id(asset_item.id, False, str(e))
-    return update_count
+    return
 
 
 def main():
@@ -133,7 +125,6 @@ def main():
     for asset_datum in asset_data:
         if asset_datum.get("patches") is None and asset_datum.get("patchId") is not None:
             print(f"Asset {asset_datum['id']} has patchId but no patches, skipping")
-            add_processed_id(asset_datum["id"], False)
             continue
         fixed_asset = change_asset_schema(asset_datum)
         if fixed_asset is None:
@@ -142,8 +133,8 @@ def main():
         assets_to_update.append(asset)
 
     if confirm(f"Are you sure you want to update {len(assets_to_update)} assets in {Config.STAGE.to_env_name()}?"):
-        update_count = update_assets(table, assets_to_update)
-        Config.LOGGER.log(f"Updated {update_count} assets out of {len(assets_to_update)}")
+        update_assets(table, assets_to_update)
+        Config.LOGGER.log(f"Updated assets out of {len(assets_to_update)}")
 
 
 if __name__ == "__main__":

--- a/aws/src/database/dynamodb/scripts/asset_table/get_assets_add_patchId_areaId.py
+++ b/aws/src/database/dynamodb/scripts/asset_table/get_assets_add_patchId_areaId.py
@@ -85,9 +85,8 @@ def update_assets(asset_table: Table, updated_assets: list[Asset]) -> int:
     for i, asset_item in enumerate(updated_assets):
         if i % 100 == 0:
             progress_bar.display(i)
-
-        asset_item.versionNumber = asset_item.versionNumber + 1 if asset_item.versionNumber else 0
         try:
+            asset_item.versionNumber = asset_item.versionNumber + 1 if asset_item.versionNumber else 0
             asset_table.put_item(Item=asdict(asset_item))
             update_count += 1
             add_processed_id(asset_item.id, True)

--- a/aws/src/database/dynamodb/scripts/asset_table/get_assets_add_patchId_areaId.py
+++ b/aws/src/database/dynamodb/scripts/asset_table/get_assets_add_patchId_areaId.py
@@ -1,3 +1,10 @@
+"""
+To set this script up locally, you will need to export the Assets DynamoDB table to JSON, see guide:
+https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/S3DataExport.HowItWorks.html
+
+The Config.INPUT_FILE should be set to the path of the exported DynamoDB JSON file
+"""
+
 from dataclasses import asdict, dataclass
 import time
 

--- a/aws/src/database/dynamodb/scripts/asset_table/get_assets_add_patchId_areaId.py
+++ b/aws/src/database/dynamodb/scripts/asset_table/get_assets_add_patchId_areaId.py
@@ -100,6 +100,7 @@ def update_assets(asset_table: Table, updated_assets: list[Asset]) -> int:
     update the asset record that are already assigned to a patch to have areaId and patchId and remove patches
     """
     delay_per_asset = round(1 / Config.ASSETS_PER_SECOND, 2)
+    print(f"Processing {Config.ASSETS_PER_SECOND} assets per second with a delay of {delay_per_asset} seconds per asset")
     update_count = 0
     progress_bar = ProgressBar(len(updated_assets))
     for i, asset_item in enumerate(updated_assets):

--- a/aws/src/database/dynamodb/scripts/asset_table/get_assets_add_patchId_areaId.py
+++ b/aws/src/database/dynamodb/scripts/asset_table/get_assets_add_patchId_areaId.py
@@ -1,85 +1,119 @@
+import os
 from dataclasses import asdict, dataclass
+from decimal import Decimal
 
 from mypy_boto3_dynamodb.service_resource import Table
-from boto3.dynamodb.types import TypeDeserializer, TypeSerializer
+from boto3.dynamodb.types import TypeDeserializer
 import json
 
 from aws.src.database.domain.dynamo_domain_objects import Asset
-from aws.src.database.dynamodb.utils.dynamodb_item_factory import DynamodbItemFactory
 from aws.src.database.dynamodb.utils.get_dynamodb_table import get_dynamodb_table
-from aws.src.utils.csv_to_dict_list import csv_to_dict_list
 from aws.src.utils.progress_bar import ProgressBar
 from aws.src.utils.logger import Logger
 from enums.enums import Stage
+from pathlib import Path
+
+from utils.confirm import confirm
+
 
 @dataclass
 class Config:
     TABLE_NAME = "Assets"
     LOGGER = Logger()
     STAGE = Stage.HOUSING_DEVELOPMENT
-    FILE_PATH = "aws/src/database/dynamodb/scripts/asset_table/input/assetsDev.json"
+    if Path(__file__).parent.name == "mtfh-scripts":
+        INPUT_FILE = "aws/src/database/dynamodb/scripts/asset_table/input/assetsDev.json"
+        PROCESSED_IDS_FILE = "aws/src/database/dynamodb/scripts/asset_table/output/processed_ids.csv"
+    else:
+        INPUT_FILE = "input/assetsDev.json"
+        PROCESSED_IDS_FILE = "aws/src/database/dynamodb/scripts/asset_table/output/processed_ids.csv"
+    LIMIT = 1  # Set to False when ready to run on all assets
 
 
-def load_assets(file_path: str) -> list[Asset]:
-    """
-    """
-    #file context manager
+def add_processed_id(asset_pk: str, success: bool):
+    print(f"Processed asset {asset_pk}")
+    with open(Config.PROCESSED_IDS_FILE, "a") as f:
+        f.write(f"{asset_pk}, {success}\n")
+
+
+def load_assets(file_path: str) -> list[dict]:
+    """Gets assets from a dynamodb json dump file and deserializes them to normal dictionaries"""
     _ds = TypeDeserializer()
-    all_assets: list[Asset] = []
-    with open(file_path, "r") as f:
-        # one object on each line
-        data = f.readlines()
-        for asset_string in data:
-            asset_raw = json.loads(asset_string)
-            deserialised_asset = {k: _ds.deserialize(asset_raw[k]) for k in asset_raw}
-            asset = Asset.from_data(deserialised_asset)
-            all_assets.append(asset) 
-            
+    all_assets = []
+    with open(Config.PROCESSED_IDS_FILE, "r") as f:
+        processed_ids = [line.split(",")[0].strip() for line in f.readlines() if line.split(",")[1].strip() == "False"]
+        print(f"Found {len(processed_ids)} processed ids out of {len(all_assets)} assets")
 
-def update_assets(asset_table: Table, assets_from_file: list[Asset]) -> int:
+    with open(file_path, "r") as f:
+        data = f.readlines()
+    for asset_string in data:
+        asset_raw = json.loads(asset_string)
+        deserialised_asset = {k: _ds.deserialize(v) for k, v in asset_raw["Item"].items()}
+        if deserialised_asset["id"] not in processed_ids:
+            all_assets.append(deserialised_asset)
+    if Config.LIMIT:
+        all_assets = all_assets[:Config.LIMIT]
+    return all_assets
+
+
+def change_asset_schema(raw_asset: dict) -> dict | None:
+    """
+    Changes the schema of the asset to match the dynamodb schema
+        - Removes patches attribute
+        - Sets patchId and areaId attributes
+    """
+    if raw_asset.get("patches") is None:
+        raw_asset["patchId"] = None
+        raw_asset["areaId"] = None
+    else:
+        if len(raw_asset["patches"]) > 1 and Config.STAGE == Stage.HOUSING_PRODUCTION:
+            Config.LOGGER.log(f"Prod Asset has more than one patch assigned to it, {raw_asset['id']}, skipping")
+            return None
+        patch = [poa_raw for poa_raw in raw_asset["patches"] if poa_raw["patchType"] == "patch"][0]
+        raw_asset["patchId"] = patch["id"] if patch else None
+        raw_asset["areaId"] = patch["parentId"] if patch else None
+        raw_asset.pop("patches", None)
+    return raw_asset
+
+
+def update_assets(asset_table: Table, updated_assets: list[Asset]) -> int:
     """
     update the asset record that are already assigned to a patch to have areaId and patchId and remove patches
     """
-    logger = Config.LOGGER
     update_count = 0
-    progress_bar = ProgressBar(len(assets_from_file))
-    for i, asset_item in enumerate(assets_from_file):
+    progress_bar = ProgressBar(len(updated_assets))
+    for i, asset_item in enumerate(updated_assets):
         if i % 100 == 0:
             progress_bar.display(i)
-        asset_pk = asset_item.id.strip()
 
-        if not asset_item.patches:
-            print(f"property doesn't have a patch assigned to it {asset_pk}")
-        else:
-            print(f"I am here {asset_pk}")
-            if len(asset_item.patches) > 1:
-                if Config.STAGE == Stage.HOUSING_PRODUCTION:
-                    continue
-                logger.log(f"Asset has more than one patch assigned to it {asset_pk}")
-                asset_item.patches = asset_item.patches[0:1]
-    
-            if asset_item.versionNumber is None:
-                asset_item.versionNumber = 0
-            else:
-                asset_item.versionNumber += 1
-
-            for patch in asset_item.patches:
-                patchId = patch.id
-                areaId = patch.parentId
-                asset_item["areaId"] = areaId if areaId else None
-                asset_item["patchId"] = patchId if patchId else None
-                asset_item["patches"].pop("patches", None)
-        asset_table.put_item(Item=asdict(asset_item))
-        update_count += 1
+        asset_item.versionNumber = asset_item.versionNumber + 1 if asset_item.versionNumber else 0
+        try:
+            asset_table.put_item(Item=asdict(asset_item))
+            update_count += 1
+            add_processed_id(asset_item.id, True)
+        except Exception as e:
+            Config.LOGGER.log(f"Failed to update asset {asset_item.id} with error {e}")
+            add_processed_id(asset_item.id, False)
     return update_count
 
 
 def main():
-    table = get_dynamodb_table(Config.TABLE_NAME, Config.STAGE)    
-    logger = Config.LOGGER
-    _file_path = Config.FILE_PATH
-    asset_csv_data = csv_to_dict_list(_file_path)
+    table = get_dynamodb_table(Config.TABLE_NAME, Config.STAGE)
 
-    # Note: Batch write to update the asset data in dynamodb
-    update_count = update_assets(table, asset_csv_data)
-    logger.log(f"Updated {update_count} records")
+    assets_to_update = []
+    asset_data = load_assets(Config.INPUT_FILE)
+    for asset_datum in asset_data:
+        if asset_datum.get("patches") is None and asset_datum.get("patchId") is not None:
+            print(f"Asset {asset_datum['id']} has patchId but no patches, skipping")
+            continue
+        fixed_asset = change_asset_schema(asset_datum)
+        asset = Asset.from_data(fixed_asset)
+        assets_to_update.append(asset)
+
+    if confirm(f"Are you sure you want to update {len(assets_to_update)} assets in {Config.STAGE.to_env_name()}?"):
+        update_count = update_assets(table, assets_to_update)
+        Config.LOGGER.log(f"Updated {update_count} assets out of {len(assets_to_update)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/aws/src/database/dynamodb/scripts/asset_table/get_assets_add_patchId_areaId.py
+++ b/aws/src/database/dynamodb/scripts/asset_table/get_assets_add_patchId_areaId.py
@@ -1,0 +1,85 @@
+from dataclasses import asdict, dataclass
+
+from mypy_boto3_dynamodb.service_resource import Table
+from boto3.dynamodb.types import TypeDeserializer, TypeSerializer
+import json
+
+from aws.src.database.domain.dynamo_domain_objects import Asset
+from aws.src.database.dynamodb.utils.dynamodb_item_factory import DynamodbItemFactory
+from aws.src.database.dynamodb.utils.get_dynamodb_table import get_dynamodb_table
+from aws.src.utils.csv_to_dict_list import csv_to_dict_list
+from aws.src.utils.progress_bar import ProgressBar
+from aws.src.utils.logger import Logger
+from enums.enums import Stage
+
+@dataclass
+class Config:
+    TABLE_NAME = "Assets"
+    LOGGER = Logger()
+    STAGE = Stage.HOUSING_DEVELOPMENT
+    FILE_PATH = "aws/src/database/dynamodb/scripts/asset_table/input/assetsDev.json"
+
+
+def load_assets(file_path: str) -> list[Asset]:
+    """
+    """
+    #file context manager
+    _ds = TypeDeserializer()
+    all_assets: list[Asset] = []
+    with open(file_path, "r") as f:
+        # one object on each line
+        data = f.readlines()
+        for asset_string in data:
+            asset_raw = json.loads(asset_string)
+            deserialised_asset = {k: _ds.deserialize(asset_raw[k]) for k in asset_raw}
+            asset = Asset.from_data(deserialised_asset)
+            all_assets.append(asset) 
+            
+
+def update_assets(asset_table: Table, assets_from_file: list[Asset]) -> int:
+    """
+    update the asset record that are already assigned to a patch to have areaId and patchId and remove patches
+    """
+    logger = Config.LOGGER
+    update_count = 0
+    progress_bar = ProgressBar(len(assets_from_file))
+    for i, asset_item in enumerate(assets_from_file):
+        if i % 100 == 0:
+            progress_bar.display(i)
+        asset_pk = asset_item.id.strip()
+
+        if not asset_item.patches:
+            print(f"property doesn't have a patch assigned to it {asset_pk}")
+        else:
+            print(f"I am here {asset_pk}")
+            if len(asset_item.patches) > 1:
+                if Config.STAGE == Stage.HOUSING_PRODUCTION:
+                    continue
+                logger.log(f"Asset has more than one patch assigned to it {asset_pk}")
+                asset_item.patches = asset_item.patches[0:1]
+    
+            if asset_item.versionNumber is None:
+                asset_item.versionNumber = 0
+            else:
+                asset_item.versionNumber += 1
+
+            for patch in asset_item.patches:
+                patchId = patch.id
+                areaId = patch.parentId
+                asset_item["areaId"] = areaId if areaId else None
+                asset_item["patchId"] = patchId if patchId else None
+                asset_item["patches"].pop("patches", None)
+        asset_table.put_item(Item=asdict(asset_item))
+        update_count += 1
+    return update_count
+
+
+def main():
+    table = get_dynamodb_table(Config.TABLE_NAME, Config.STAGE)    
+    logger = Config.LOGGER
+    _file_path = Config.FILE_PATH
+    asset_csv_data = csv_to_dict_list(_file_path)
+
+    # Note: Batch write to update the asset data in dynamodb
+    update_count = update_assets(table, asset_csv_data)
+    logger.log(f"Updated {update_count} records")

--- a/aws/src/database/dynamodb/scripts/asset_table/set_is_active.py
+++ b/aws/src/database/dynamodb/scripts/asset_table/set_is_active.py
@@ -1,0 +1,141 @@
+"""
+To set this script up locally, you will need to export the Assets DynamoDB table to JSON, see guide:
+https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/S3DataExport.HowItWorks.html
+
+The Config.INPUT_FILE should be set to the path of the exported DynamoDB JSON file
+"""
+
+from dataclasses import asdict, dataclass
+import time
+
+from mypy_boto3_dynamodb.service_resource import Table
+from boto3.dynamodb.types import TypeDeserializer
+import json
+
+from aws.src.database.domain.dynamo_domain_objects import Asset
+from aws.src.database.dynamodb.utils.get_dynamodb_table import get_dynamodb_table
+from aws.src.utils.progress_bar import ProgressBar
+from aws.src.utils.logger import Logger
+from enums.enums import Stage
+from pathlib import Path
+
+from utils.confirm import confirm
+
+
+@dataclass
+class Config:
+    TABLE_NAME = "Assets"
+    LOGGER = Logger()
+    STAGE = Stage.HOUSING_DEVELOPMENT
+    if Path(__file__).parent.name == "mtfh-scripts":
+        INPUT_FILE = "aws/src/database/dynamodb/scripts/asset_table/input/assetsDev.json"
+        PROCESSED_IDS_FILE = "aws/src/database/dynamodb/scripts/asset_table/output/processed_ids.csv"
+    else:
+        INPUT_FILE = "input/assetsDev.json"
+        PROCESSED_IDS_FILE = "output/processed_ids_set_isactive.csv"
+    ASSETS_PER_SECOND = 8 / 1.5
+    LIMIT = False  # Set to False when ready to run on all assets
+
+
+def add_processed_id(asset_pk: str, success: bool, reason: str = ""):
+    message = f"{asset_pk}, {success}, {reason}"
+    Config.LOGGER.log(message)
+    with open(Config.PROCESSED_IDS_FILE, "a") as f:
+        f.write("\n" + message)
+
+
+def date_is_past(date: str) -> bool:
+    """Checks if a date is in the past"""
+    current_date = time.strftime("%Y-%m-%d")
+    return date < current_date
+
+
+def load_assets(file_path: str) -> list[dict]:
+    """Gets assets from a dynamodb json dump file and deserializes them to normal dictionaries"""
+    _ds = TypeDeserializer()
+    all_assets = []
+
+    with open(file_path, "r") as f:
+        data = f.readlines()
+
+    with open(Config.PROCESSED_IDS_FILE, "r") as f:
+        lines = f.readlines()
+        processed_ids = [line.split(",")[0].strip() for line in lines]
+        print(f"Found {len(processed_ids)} processed ids out of {len(data)} assets")
+
+    for asset_string in data:
+        asset_raw = json.loads(asset_string)
+        deserialised_asset = {k: _ds.deserialize(v) for k, v in asset_raw["Item"].items()}
+        if deserialised_asset["id"] not in processed_ids:
+            all_assets.append(deserialised_asset)
+    if Config.LIMIT:
+        all_assets = all_assets[:Config.LIMIT]
+    print(f"Processing {len(all_assets)} out of {len(data)} assets")
+    return all_assets
+
+
+def set_is_active(raw_asset: dict) -> dict | None:
+    """Sets the isActive attribute of the asset depending on the asset tenure start/end date"""
+    if not raw_asset.get("rootAsset"):
+        add_processed_id(raw_asset["id"], False, "Has no root asset - required field")
+        return None
+    try:
+        if raw_asset.get("tenure") is None:
+            raw_asset["isActive"] = False
+        elif raw_asset["tenure"].get("endOfTenureDate") is None:
+            raw_asset["isActive"] = True
+        elif date_is_past(raw_asset["tenure"]["endOfTenureDate"]):
+            raw_asset["isActive"] = False
+        else:
+            raw_asset["isActive"] = True
+        return raw_asset
+    except Exception as e:
+        Config.LOGGER.log(f"Failed to process asset {raw_asset['id']} with error {e}")
+        add_processed_id(raw_asset["id"], False, str(e))
+        return None
+
+
+def update_assets(asset_table: Table, updated_assets: list[Asset]):
+    """update the asset record that are already assigned to a patch to have areaId and patchId and remove patches"""
+    delay_per_asset = round(1 / Config.ASSETS_PER_SECOND, 2)
+    print(f"Processing {Config.ASSETS_PER_SECOND} assets per second with a delay of {delay_per_asset} seconds per asset")
+    progress_bar = ProgressBar(len(updated_assets))
+    for i, asset_item in enumerate(updated_assets):
+        if i % 100 == 0:
+            progress_bar.display(i)
+        try:
+            asset_item.versionNumber = asset_item.versionNumber + 1 if asset_item.versionNumber else 0
+            asset_table.put_item(Item=asdict(asset_item))
+            add_processed_id(asset_item.id, True)
+            time.sleep(delay_per_asset)
+        except Exception as e:
+            Config.LOGGER.log(f"Failed to update asset {asset_item.id} with error {e}")
+            add_processed_id(asset_item.id, False, str(e))
+    return
+
+
+def main():
+    table = get_dynamodb_table(Config.TABLE_NAME, Config.STAGE)
+
+    assets_to_update = []
+    asset_data = load_assets(Config.INPUT_FILE)
+    for asset_datum in asset_data:
+        if "isActive" not in asset_datum:
+            add_processed_id(asset_datum["id"], False, "Has no isActive property set")
+            continue
+        if asset_datum.get("isActive") not in [None, ""]:
+            add_processed_id(asset_datum["id"], False, "Has a valid isActive attribute")
+            continue
+        fixed_asset = set_is_active(asset_datum)
+        if fixed_asset is None:
+            continue
+        asset = Asset.from_data(fixed_asset)
+        assets_to_update.append(asset)
+
+    if confirm(f"Are you sure you want to update {len(assets_to_update)} assets in {Config.STAGE.to_env_name()}?"):
+        update_assets(table, assets_to_update)
+        Config.LOGGER.log(f"Updated assets out of {len(assets_to_update)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/aws/src/database/multi_table/amend_tenure.py
+++ b/aws/src/database/multi_table/amend_tenure.py
@@ -38,7 +38,7 @@ _ES_DOMAIN_PARAM_PATH = f"/housing-search-api/{STAGE_PARAM}/elasticsearch-domain
 _JUMP_BOX_INSTANCE_NAME_PATH = "platform-apis-jump-box-instance-name"
 
 # Parameters
-ssm_client = generate_aws_service("ssm", STAGE, "client")
+ssm_client = generate_aws_service("ssm", STAGE)
 ES_DOMAIN = ssm_client.get_parameter(Name=_ES_DOMAIN_PARAM_PATH)["Parameter"]["Value"]
 INSTANCE_ID = ssm_client.get_parameter(Name=_JUMP_BOX_INSTANCE_NAME_PATH)["Parameter"]["Value"]
 
@@ -153,13 +153,13 @@ def update_property_elasticsearch(property_pk):
 
 
 def get_tenure_dynamodb(primary_key=TENURE_ID) -> dict:
-    tenure_table: Table = generate_aws_service("dynamodb", STAGE, "resource").Table(TENURE_TABLE_NAME)
+    tenure_table: Table = generate_aws_service("dynamodb", STAGE).Table(TENURE_TABLE_NAME)
     tenure_item: dict = tenure_table.get_item(Key={"id": primary_key})["Item"]
     return tenure_item
 
 
 def update_tenure_dynamodb(tenure_item: dict):
-    tenure_table: Table = generate_aws_service("dynamodb", STAGE, "resource").Table(TENURE_TABLE_NAME)
+    tenure_table: Table = generate_aws_service("dynamodb", STAGE).Table(TENURE_TABLE_NAME)
     print("\n== DynamoDB Item ==")
     pprint(tenure_item)
     print("== DynamoDB Item ==")
@@ -179,7 +179,7 @@ def update_tenure_dynamodb(tenure_item: dict):
 
 
 def update_property_dynamodb(tenure_item: dict):
-    asset_table: Table = generate_aws_service("dynamodb", STAGE, "resource").Table(PROPERTY_TABLE_NAME)
+    asset_table: Table = generate_aws_service("dynamodb", STAGE).Table(PROPERTY_TABLE_NAME)
     property_id: str = tenure_item["tenuredAsset"]["id"]
     property_item: dict = asset_table.get_item(Key={"id": property_id})["Item"]
     property_tenure = property_item["tenure"]
@@ -204,7 +204,7 @@ def update_property_dynamodb(tenure_item: dict):
 
 
 def update_persons_dynamodb(tenure_item: dict):
-    persons_table: Table = generate_aws_service("dynamodb", STAGE, "resource").Table(PERSONS_TABLE_NAME)
+    persons_table: Table = generate_aws_service("dynamodb", STAGE).Table(PERSONS_TABLE_NAME)
     tenure_id = tenure_item["id"]
 
     household_members: list[dict] = tenure_item["householdMembers"]

--- a/aws/src/database/opensearch/housing-search/elasticsearch_client.py
+++ b/aws/src/database/opensearch/housing-search/elasticsearch_client.py
@@ -1,0 +1,78 @@
+import elasticsearch
+from elasticsearch import Elasticsearch
+
+
+class LocalElasticsearchClient:
+    def __init__(self, index: str, port: int = 3333):
+        """
+        Create a connection to a local Elasticsearch instance
+        :param port: Port to connect to
+        :param index: Index to connect to
+        """
+        self.port = port
+        self.es_instance = Elasticsearch(f"https://localhost:{port}", verify_certs=False, index=index)
+        self._check_connection()
+        self._index = index
+
+        # Check if index exists
+        if not self.es_instance.indices.exists(index):
+            raise ValueError(f"Index {index} does not exist. Valid indices are {self.list_all_indices()}")
+
+    def get(self, doc_id: str) -> dict:
+        """Return a document in an index by its ID"""
+        return self.es_instance.get(index=self._index, id=doc_id)
+
+    def query(self, query: dict, size: int = 1000) -> list:
+        """Return all documents in an index matching a query"""
+        query = {"query": query}
+        res = self.es_instance.search(index=self._index, body=query, size=size)
+        print(f"Found {len(res['hits']['hits'])} documents in {self._index} out of {res['hits']['total']['value']}")
+        return res["hits"]["hits"]
+
+    def index(self, doc_id: str, body: dict):
+        """Put a document in an index"""
+        self.es_instance.index(index=self._index, id=doc_id, body=body)
+
+    def update(self, doc_id: str, body: dict):
+        """Update a document in an index"""
+        self.es_instance.update(index=self._index, id=doc_id, body={"doc": body})
+
+    def delete(self, doc_id: str):
+        """Delete a document in an index"""
+        self.es_instance.delete(index=self._index, id=doc_id)
+
+    def match_all(self, size: int = 1000) -> list:
+        """Return all documents in an index up to the size limit"""
+        query = {"match_all": {}}
+        return self.query(query, size)
+
+    def get_by_attribute(self, attribute: str, value: str, size=1000) -> list:
+        """Return all documents in an index with a given attribute value"""
+        query = {
+            "match": {
+                attribute: {
+                    "query": value,
+                    "fuzziness": "AUTO",
+                    "operator": "and",
+                }
+            }
+        }
+        return self.query(query, size)
+
+    def set_attribute(self, index: str, doc_id: str, attribute: str, value: str):
+        """Set an attribute for a document in an index"""
+        self.es_instance.update(index=index, id=doc_id, body={"doc": {attribute: value}})
+
+    def delete_attribute(self, index: str, doc_id: str, attribute: str):
+        """Delete an attribute for a document in an index"""
+        self.es_instance.update(index=index, id=doc_id, body={"script": f"ctx._source.remove('{attribute}')"})
+
+    def list_all_indices(self) -> list:
+        """Return all indices in the Elasticsearch instance"""
+        return list(self.es_instance.indices.get_alias("*").keys())
+
+    def _check_connection(self):
+        try:
+            self.es_instance.info()
+        except elasticsearch.exceptions.ConnectionError:
+            print(f"Could not connect to ES at localhost:{self.port} - are you port forwarding?")

--- a/aws/src/database/opensearch/housing-search/es_check.py
+++ b/aws/src/database/opensearch/housing-search/es_check.py
@@ -1,4 +1,3 @@
-import elasticsearch
 from elasticsearch import Elasticsearch
 
 from elasticsearch_client import LocalElasticsearchClient

--- a/aws/src/database/opensearch/housing-search/es_check.py
+++ b/aws/src/database/opensearch/housing-search/es_check.py
@@ -1,24 +1,15 @@
-from mypy_boto3_opensearch.client import OpenSearchServiceClient
-
-from aws.src.authentication.generate_aws_resource import generate_aws_service
-from enums.enums import Stage
-
+import elasticsearch
 from elasticsearch import Elasticsearch
 
-
-def elastic_search():
-    es = Elasticsearch("https://localhost:3333", verify_certs=False)
-    res = es.search(index="staff", body={"query": {"match_all": {}}})["hits"]["hits"]
-    print([f'{person["_source"]["firstName"]} {person["_source"]["lastName"]}' for person in res])
+from elasticsearch_client import LocalElasticsearchClient
 
 
-def opensearch():
-    os: OpenSearchServiceClient = generate_aws_service("opensearch", Stage.HOUSING_DEVELOPMENT, "client")
-    domains = os.list_domain_names()['DomainNames']
-    print([domain['DomainName'] for domain in domains])
-    res2 = os.describe_domain(DomainName="housing-search-api-es")
-    print(res2)
+def main():
+    es_client = LocalElasticsearchClient(index="nov22-assets", port=3333)
+    results = es_client.match_all()
+
+    print(results)
 
 
 if __name__ == "__main__":
-    elastic_search()
+    main()

--- a/aws/src/database/opensearch/housing-search/opensearch.py
+++ b/aws/src/database/opensearch/housing-search/opensearch.py
@@ -1,0 +1,11 @@
+from mypy_boto3_opensearch.client import OpenSearchServiceClient
+
+from aws.src.authentication.generate_aws_resource import generate_aws_service
+from enums.enums import Stage
+
+def opensearch():
+    os: OpenSearchServiceClient = generate_aws_service("opensearch", Stage.HOUSING_DEVELOPMENT, "client")
+    domains = os.list_domain_names()['DomainNames']
+    print([domain['DomainName'] for domain in domains])
+    result = os.describe_domain(DomainName="housing-search-api-es")
+    print(result)

--- a/aws/src/database/rds/repairs/session_for_repairs.py
+++ b/aws/src/database/rds/repairs/session_for_repairs.py
@@ -25,7 +25,7 @@ def session_for_repairs(stage: Stage, expire_on_commit=True, local_port=5432) ->
     pg_username_path = f"/repairs-api/{stage.to_env_name()}/postgres-username"
     pg_password_path = f"/repairs-api/{stage.to_env_name()}/postgres-password"
 
-    ssm: SSMClient = generate_aws_service('ssm', stage, 'client')
+    ssm: SSMClient = generate_aws_service('ssm', stage)
     username = ssm.get_parameter(Name=pg_username_path)['Parameter']['Value']
     password = ssm.get_parameter(Name=pg_password_path)['Parameter']['Value']
 

--- a/aws/src/utils/logger.py
+++ b/aws/src/utils/logger.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 
 
@@ -8,7 +8,8 @@ class Logger:
         self.log_file_name = "logs" if log_file_name is None else log_file_name
         self.log_file_dir = "logs" if log_file_dir is None else log_file_dir
         self.log_file = f"{self.log_file_dir}/{self.log_file_name}.txt"
-        self.log(f'\n== Logging started: {datetime.now().strftime("%d/%m/%Y %H:%M:%S")} ==')
+        self.start_time = datetime.now()
+        self.log(f'\n== Logging started: {self.start_time.strftime("%d/%m/%Y %H:%M:%S")} ==')
 
     def log(self, message: str, end="\n"):
         """
@@ -22,6 +23,11 @@ class Logger:
         with open(self.log_file, "a") as outfile:
             print(message, file=outfile, end=end)
         print(message, end=end)
+
+    def log_end(self):
+        diff = datetime.now() - self.start_time
+        duration = timedelta(seconds=diff.total_seconds())
+        self.log(f'== Logging ended: {datetime.now().strftime("%d/%m/%Y %H:%M:%S")} duration {duration} ==')
 
     @staticmethod
     def log_call(logger):

--- a/aws/src/utils/progress_bar.py
+++ b/aws/src/utils/progress_bar.py
@@ -16,14 +16,6 @@ class ProgressBar:
         :param current: Current number
         :param note: Note to add to the end of the progress bar
         """
-
-        normalized_current = round(((current / self.total) * 100) / self.BAR_LENGTH)
-
-        bar = f"Progress: [{normalized_current * '#'}{(self.BAR_LENGTH - normalized_current) * ' '}] {current}/{self.total} " \
-
-        padded_bar = f"{self.separation}{bar}{self.separation}"
-        print(padded_bar)
-
         progress = current / self.total
         block = int(round(self.BAR_LENGTH * progress))
         bar = f"Progress: [{block * '#'}{(self.BAR_LENGTH - block) * ' '}] {current}/{self.total} " \

--- a/aws/src/utils/safe_object_from_dict.py
+++ b/aws/src/utils/safe_object_from_dict.py
@@ -16,12 +16,12 @@ def safe_object_from_dict(object_type: type[T], data: dict) -> T:
 
     for key in list(data.keys()):
         if key not in object_type.__annotations__.keys():
-            print(f"WARNING: {key} not in class {object_type.__name__}")
+            # print(f"WARNING: {key} not in class {object_type.__name__}")
             del data[key]
 
     for key in object_type.__annotations__.keys():
         if key not in data.keys():
-            print(f"WARNING: {key} from class {object_type.__name__} not in data")
+            # print(f"WARNING: {key} from class {object_type.__name__} not in data")
             data[key] = None
 
     return object_type(**data)

--- a/aws/src/utils/safe_object_from_dict.py
+++ b/aws/src/utils/safe_object_from_dict.py
@@ -16,12 +16,12 @@ def safe_object_from_dict(object_type: type[T], data: dict) -> T:
 
     for key in list(data.keys()):
         if key not in object_type.__annotations__.keys():
-            # print(f"WARNING: {key} not in class {object_type.__name__}")
+            print(f"WARNING: {key} not in class {object_type.__name__}")
             del data[key]
 
     for key in object_type.__annotations__.keys():
         if key not in data.keys():
-            # print(f"WARNING: {key} from class {object_type.__name__} not in data")
+            print(f"WARNING: {key} from class {object_type.__name__} not in data")
             data[key] = None
 
     return object_type(**data)

--- a/gcp/src/service_account/get_credentials.py
+++ b/gcp/src/service_account/get_credentials.py
@@ -15,7 +15,7 @@ def get_credentials(stage = Stage.HOUSING_DEVELOPMENT, url_stage: str = None) ->
     """
     if url_stage is None:
         url_stage = stage.value.replace("housing-", "")
-    ssm: SSMClient = generate_aws_service("ssm", stage, "client")
+    ssm: SSMClient = generate_aws_service("ssm", stage)
     path = f"/housing-finance/{url_stage}/google-application-credentials-json"
     credentials = ssm.get_parameter(Name=path)["Parameter"]["Value"]
     return credentials

--- a/use_cases.py
+++ b/use_cases.py
@@ -10,10 +10,12 @@
 # from aws.src.database.dynamodb.scripts.contact_details_table.scan_and_patch_new_phone_numbers import main as scan_and_patch_new_phone_numbers_main
 #from aws.src.database.dynamodb.scripts.asset_table.patch_asset_with_additional_boiler_house_id import main as update_boilerhouse
 # from gcp.src.service_account.main import main as service_account_main
+from aws.src.database.dynamodb.scripts.asset_table.get_assets_add_patchId_areaId import main as get_assets_add_patchId_areaId
 
 if __name__ == "__main__":
     # 1) IMPORTANT: Uncomment and click into functions in the imports to view definitions and edit config
     #     - e.g. set STAGE to "development" or "production"
     # 2) Call functions here
+    get_assets_add_patchId_areaId()
     
     pass

--- a/use_cases.py
+++ b/use_cases.py
@@ -1,21 +1,8 @@
-# TODO: Uncomment the method and import you want to use
-# from aws.src.database.dynamodb.scripts.asset_table.patch_asset_with_additional_data import main as patch_asset_with_additional_data_main
-# from aws.src.database.dynamodb.scripts.asset_table.get_assets_by_prop_ref import main as get_assets_by_prop_ref_main
-# from aws.src.database.dynamodb.scripts.asset_table.add_patches_data import main as add_patches_data_dynamodb_main
-# from aws.src.database.dynamodb.scripts.asset_table.get_assets import main as get_assets_dynamodb_main
-# from aws.src.database.dynamodb.scripts.person_table.get_housing_officers_and_area_managers import \
-#     main as get_housing_officers_and_area_managers_main
-# from aws.src.database.multi_table.amend_tenure import main as amend_tenure_main
-# from aws.src.database.multi_table.find_persons_for_properties import main as find_persons_for_properties_main
-# from aws.src.database.dynamodb.scripts.contact_details_table.scan_and_patch_new_phone_numbers import main as scan_and_patch_new_phone_numbers_main
-#from aws.src.database.dynamodb.scripts.asset_table.patch_asset_with_additional_boiler_house_id import main as update_boilerhouse
-# from gcp.src.service_account.main import main as service_account_main
-from aws.src.database.dynamodb.scripts.asset_table.get_assets_add_patchId_areaId import main as get_assets_add_patchId_areaId
+# Import function here and call it below, e.g.
+# from aws.src.database ... import my_script
 
 if __name__ == "__main__":
-    # 1) IMPORTANT: Uncomment and click into functions in the imports to view definitions and edit config
-    #     - e.g. set STAGE to "development" or "production"
-    # 2) Call functions here
-    get_assets_add_patchId_areaId()
-    
+    # 1) Edit and configure scripts (including stage) in source files
+    # 2) Call functions here, e.g my_script()
+
     pass


### PR DESCRIPTION
For all assets in the asset Dynamodb table:
- Set `patchId` and `areaId` properties based on data in their `patches[]` property
- Delete their `patches[]` property

This script uses an export of the DynamoDB table to JSON to not need to perform scan operations.
Information on this process here: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/S3DataExport.HowItWorks.html