### PR TITLE
Add devcontainer config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/devcontainers/python:1-3.11-bullseye
+
+RUN sudo apt update
+
+COPY ./.devcontainer/scripts/ scripts/
+
+RUN sh scripts/1_pre_requirements.sh
+
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+RUN sh scripts/2_post_requirements.sh

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "Python 3",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"context": ".."
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/aws-cli:1": {},
+		"ghcr.io/jungaretti/features/make:1": {}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-azuretools.vscode-docker",
+				"ms-vscode.makefile-tools",
+				"ms-python.black-formatter",
+				"tamasfe.even-better-toml",
+				"lfm.vscode-makefile-term"			]
+		}
+	},
+
+	// Mounts the host .aws folder into the container to allow profile access
+	"mounts": [
+		"source=${env:HOME}/.aws,target=/home/vscode/.aws,type=bind" // macOS, Linux, WSL
+		// "source=${env:USERPROFILE}/.aws,target=/home/vscode/.aws,type=bind" // Windows
+	]
+}

--- a/.devcontainer/scripts/1_pre_requirements.sh
+++ b/.devcontainer/scripts/1_pre_requirements.sh
@@ -1,0 +1,4 @@
+# This file should install dependencies that are necessary to install the python requirements.txt only
+
+# Install Unix ODBC driver
+sudo apt install unixodbc-dev -y

--- a/.devcontainer/scripts/2_post_requirements.sh
+++ b/.devcontainer/scripts/2_post_requirements.sh
@@ -1,0 +1,19 @@
+# This script runs after installing the pip requirements but before the Docker container has finished building
+
+# Install session manager plugin for aws cli
+curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb";
+sudo dpkg -i session-manager-plugin.deb;
+rm session-manager-plugin.deb;
+
+# Install SQL Server ODBC driver
+curl https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc
+
+curl https://packages.microsoft.com/config/debian/11/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
+
+sudo apt-get update
+sudo ACCEPT_EULA=Y apt-get install -y msodbcsql17
+sudo ACCEPT_EULA=Y apt-get install -y mssql-tools
+echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
+source ~/.bashrc
+sudo apt-get install -y unixodbc-dev
+sudo apt-get install -y libgssapi-krb5-2

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,7 @@ __init__.py
 
 venv
 *.env
-
-*.env
+.env
 
 *.txt
 !requirements.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-.vscode
+*.json
+!.vscode/*.json
+!.devcontainer/*.json
+
 .idea
 __pycache__
 __init__.py
@@ -16,8 +19,6 @@ venv
 *.tsv
 !aws/tests/test_data/*.csv
 !aws/tests/test_data/*.tsv
-
-*.json
 
 config.py
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    // Allows running and debugging the current file with the play button
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Current File (Integrated Terminal)",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal",
+            "cwd": "${fileDirname}",
+            "purpose":["debug-in-terminal"],
+            "env": {
+                "PYTHONPATH": "${cwd}"
+            }
+        },
+    ],
+    
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
     "editor.defaultFormatter": "ms-python.black-formatter",
     "python.analysis.typeCheckingMode": "standard",
+    "[json]": {
+        "editor.defaultFormatter": "vscode.json-language-features"
+    },
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "editor.defaultFormatter": "ms-python.black-formatter",
+    "python.analysis.typeCheckingMode": "standard",
+}

--- a/README.md
+++ b/README.md
@@ -2,23 +2,47 @@
 
 Scripts for use within Modern Tools For Housing
 
-## Requirements
+Provides utils to facilitate connecting to and scripting against:
+- DynamoDB
+- RDS (with ORM bindings)
+- Elasticsearch
 
-- Docker Desktop or Docker Engine installed with the Docker daemon active
-- [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension in VSCode or equivalent in your favourite IDE
+# Requirements & Setup
 
-## Setup / Installation
+## Without Devcontainers
 
-1. Clone this repository
-2. Look at the .devcontainer/devcontainer.json file and select the option in the "mounts" section based on if you are on Windows or Mac/Linux/WSL
-3. Select the prompt to "Reopen in Container" or equivalent when it appears
+1. Ensure you have a recent version of [Python 3](https://www.python.org/downloads/) (e.g. Python 3.11)
+2. Ensure you have Pip package manager for Python 3. Try `python3 -m pip --version` to see if you have it installed. If not,
+   try `python3 -m ensurepip` to install it.
+3. Make a venv (local package directory) with `python3 -m venv venv`
+4. Activate the venv
+   - Linux / MacOS: Run `source venv/bin/activate`
+   - Windows: Run `./venv/Scripts/activate.bat` or `./venv/Scripts/activate.ps1` depending on what's available
+5. Optionally verify the venv is active:
+   - Linux / MacOS: Run `echo $VIRTUAL_ENV` and check it points to the venv
+   - Windows: Run `echo %VIRTUAL_ENV%` and check it points to the venv
+6. Run `python3 -m pip install -r requirements.txt` in the root directory of the repository to install all requirements
+   into the venv.
+
+## Using Devcontainers
+
+This will simplify setup and install various useful tools.
+
+### Note for Windows
+You must clone and use this repository in WSL for acceptable performance. Also, on Windows you should consider removing the AWS mount in the Devcontainer configuration to improve performance if you notice it is slow. You must mount your AWS directory from your WSL filesystem, not your Windows filesystem. If you experience issues, consider setting up without devcontainers. This is just a limitation of Docker on Windows with no clear fix.
+
+### Steps
+1. Ensure you have Docker Desktop or Docker Engine installed with the Docker daemon active
+2. Ensure you have the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension in VSCode or equivalent in your favourite IDE
+3. Look at the .devcontainer/devcontainer.json file and select the option in the "mounts" section based on if you are on Windows or Mac/Linux/WSL
+4. Select the prompt to "Reopen in Container" or equivalent when it appears
 
 Note: First setup may take several minutes to build the Docker container, but subsequent builds will only be a few seconds.
 The common rules of Docker apply where it is built in layers from .devcontainer/Dockerfile and caches layers where possible.
 
 ## Setup / AWS
 
-Note: Your ~/.aws directory will be mounted into the Docker container, so you can set up your AWS credentials on your host machine and access them in the container.
+Note: Your ~/.aws directory will be mounted into the Docker container if you're using a devcontainer, so you can set up your AWS credentials on your host machine and access them in the container.
 
 Install the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) -
 the scripts use AWS CLI profile based authentication to make calls to AWS.
@@ -42,4 +66,6 @@ like `Error when retrieving token from sso: Token has expired and refresh failed
 
 You should not need further dependencies to run any scripts.
 
-Open a script and hit the play button in VSCode or your IDE to run or debug it.
+Open a script and hit the play button in VSCode or your IDE to debug it - on VSCode this will use the debug configuration in the .vscode/launch.json file.
+
+Python convention is to create a `main` function in a file and call it inside an `if __name__ == "__main__":` block at the end of the file.

--- a/README.md
+++ b/README.md
@@ -2,32 +2,23 @@
 
 Scripts for use within Modern Tools For Housing
 
-### NOTE:
-
-These Python commands may be different depending on your OS and how you installed Python.
-
-**Try `python` instead of `python3` if you get "command not found".**
-
 ## Requirements
 
-1. A recent version of [Python 3](https://www.python.org/downloads/) (e.g. Python 3.11)
-2. The Pip package manager for Python 3. Try `python3 -m pip --version` to see if you have it installed. If not,
-   try `python3 -m ensurepip` to install it.
+- Docker Desktop or Docker Engine installed with the Docker daemon active
+- [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension in VSCode or equivalent in your favourite IDE
 
 ## Setup / Installation
 
 1. Clone this repository
-2. Make a venv (local package directory) with `python3 -m venv venv`
-3. Activate the venv
-   - Linux / MacOS: Run `source venv/bin/activate`
-   - Windows: Run `./venv/bin/activate.bat` or `./venv/bin/activate.ps1` depending on what's available (can also be in the \Scripts subdirectory)
-4. Optionally verify the venv is active:
-   - Linux / MacOS: Run `echo $VIRTUAL_ENV` and check it points to the venv
-   - Windows: Run `echo %VIRTUAL_ENV%` and check it points to the venv
-5. Run `python3 -m pip install -r requirements.txt` in the root directory of the repository to install all requirements
-   into the venv.
+2. Look at the .devcontainer/devcontainer.json file and select the option in the "mounts" section based on if you are on Windows or Mac/Linux/WSL
+3. Select the prompt to "Reopen in Container" or equivalent when it appears
+
+Note: First setup may take several minutes to build the Docker container, but subsequent builds will only be a few seconds.
+The common rules of Docker apply where it is built in layers from .devcontainer/Dockerfile and caches layers where possible.
 
 ## Setup / AWS
+
+Note: Your ~/.aws directory will be mounted into the Docker container, so you can set up your AWS credentials on your host machine and access them in the container.
 
 Install the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) -
 the scripts use AWS CLI profile based authentication to make calls to AWS.
@@ -51,16 +42,4 @@ like `Error when retrieving token from sso: Token has expired and refresh failed
 
 You should not need further dependencies to run any scripts.
 
-1. Open the `main.py` file in the root directory of the repository.
-2. Click into the functions you want to run and set the Config objects in the files to match your needs.
-3. Call the function in the main section of the `main.py` file.
-4. Run `python3 main.py` in the root directory of the repository to run the script.
-
-This is done from the main.py file to ensure that imports are relative to the root directory of the repository.
-
-## Running tests
-
-Tests are in Pytest which is installed as a dependency
-
-1. Open the directory of the test files to run
-2. Run `pytest {test_file_name}.py` to run tests in a file or just `pytest` to run all tests
+Open a script and hit the play button in VSCode or your IDE to run or debug it.

--- a/aws/authentication/generate_aws_resource.py
+++ b/aws/authentication/generate_aws_resource.py
@@ -9,9 +9,9 @@ from enums.enums import Stage
 
 
 def get_session_for_stage(stage: Stage | str) -> Session:
-    try:
+    if isinstance(stage, Stage):
         stage_profile = stage.value.lower()
-    except AttributeError:
+    else:
         stage_profile = stage.lower()
 
     # Get and validate credentials
@@ -31,8 +31,8 @@ def get_session_for_stage(stage: Stage | str) -> Session:
                   f"Hit enter to try again")
         except botocore.exceptions.ClientError:
             # Thrown when profile manually configured in ~/.aws/credentials
-            input(f"\nInvalid Access key ID / Secret access key / Session token for profile {stage.value.lower()}.\n"
-                  f"Update the credentials in your .aws/credentials file for the {stage.value.lower()} profile.\n"
+            input(f"\nInvalid Access key ID / Secret access key / Session token for profile {stage_profile}.\n"
+                  f"Update the credentials in your .aws/credentials file for the {stage_profile} profile.\n"
                   f"Hit enter to try again")
         except botocore.exceptions.TokenRetrievalError:
             # Thrown when using SSO and credentials have expired
@@ -63,9 +63,9 @@ def generate_aws_service(service_name: str, stage: Stage) -> Any:
     valid_resources = ["dynamodb"]
     valid_clients = ["ssm", "rds", "es", "opensearch"]
     if service_name in valid_resources:
-        service: ServiceResource = session.resource(service_name)
+        service: ServiceResource = session.resource(service_name) # type: ignore
     elif service_name in valid_clients:
-        service: ServiceResource = session.client(service_name)
+        service: ServiceResource = session.client(service_name) # type: ignore
     else:
         raise ValueError(f"Valid service names are {valid_resources + valid_clients}")
     return service

--- a/main.py
+++ b/main.py
@@ -1,7 +1,0 @@
-# Import function here and call it below, e.g.
-# from aws.database ... import my_script
-
-if __name__ == "__main__":
-    # 1) Edit and configure scripts (including stage) in source files
-    # 2) Call functions here, e.g my_script()
-    pass


### PR DESCRIPTION
I've been using a devcontainer for this repo for a few weeks and it made the setup and environment management easier than having all the dependencies installed locally.

The README has been updated to explain the process of setting up the devcontainer, which is simpler than the prior steps.

The controlled environment of the devcontainer made it possible to add these features out of the box to the dev environment:

- AWS Session manager and database drivers for database scripts

-  "Hit play button to debug file" so there's no more need to import scripts into the root directory to run them

- Comprehensive code analysis with Microsoft's PyLance that can catch any potential type errors and enforce type annotations