### PR TITLE
Script that was run to clear unused ES instances

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,6 +24,5 @@
 	// Mounts the host .aws folder into the container to allow profile access
 	"mounts": [
 		"source=${env:HOME}/.aws,target=/home/vscode/.aws,type=bind" // macOS, Linux, WSL
-		// "source=${env:USERPROFILE}/.aws,target=/home/vscode/.aws,type=bind" // Windows
 	]
 }

--- a/README.md
+++ b/README.md
@@ -29,13 +29,12 @@ Provides utils to facilitate connecting to and scripting against:
 This will simplify setup and install various useful tools.
 
 ### Note for Windows
-You must clone and use this repository in WSL for acceptable performance. Also, on Windows you should consider removing the AWS mount in the Devcontainer configuration to improve performance if you notice it is slow. You must mount your AWS directory from your WSL filesystem, not your Windows filesystem. If you experience issues, consider setting up without devcontainers. This is just a limitation of Docker on Windows with no clear fix.
+You must clone and use this repository in WSL for acceptable performance. You must mount your AWS directory from your WSL filesystem, not your Windows filesystem. If you experience issues, consider setting up without devcontainers. This is just a limitation of Docker on Windows with no clear fix.
 
 ### Steps
 1. Ensure you have Docker Desktop or Docker Engine installed with the Docker daemon active
 2. Ensure you have the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension in VSCode or equivalent in your favourite IDE
-3. Look at the .devcontainer/devcontainer.json file and select the option in the "mounts" section based on if you are on Windows or Mac/Linux/WSL
-4. Select the prompt to "Reopen in Container" or equivalent when it appears
+3. Select the prompt to "Reopen in Container" or equivalent when it appears or access it from the command menu (Ctrl+Shift+P)
 
 Note: First setup may take several minutes to build the Docker container, but subsequent builds will only be a few seconds.
 The common rules of Docker apply where it is built in layers from .devcontainer/Dockerfile and caches layers where possible.

--- a/aws/database/opensearch/addresses/Makefile
+++ b/aws/database/opensearch/addresses/Makefile
@@ -46,5 +46,9 @@ port_forwarding_to_addresses_es:
 		--document AWS-StartPortForwardingSessionToRemoteHost \
 		--parameters ${DATABASE_PARAMS}
 
+kibana:
+	curl -k https://127.0.0.1:${LOCAL_PORT}
+	sensible-browser https://localhost:${LOCAL_PORT}/_plugin/kibana
+
 reset:
 	fuser -n tcp -k ${LOCAL_PORT} && echo "Port ${LOCAL_PORT} cleared" || echo "Port ${LOCAL_PORT} not in use"

--- a/aws/database/opensearch/addresses/scripts/clear_unused_indexes.py
+++ b/aws/database/opensearch/addresses/scripts/clear_unused_indexes.py
@@ -42,8 +42,5 @@ def main():
             es_client.delete_index(index_to_clear)
 
 
-
-
-
 if __name__ == "__main__":
     main()

--- a/aws/database/opensearch/addresses/scripts/clear_unused_indexes.py
+++ b/aws/database/opensearch/addresses/scripts/clear_unused_indexes.py
@@ -1,0 +1,51 @@
+from aws.database.opensearch.client.elasticsearch_client import LocalElasticsearchClient
+from utils.confirm import confirm
+
+
+def find_aliased_indexes(es_client: LocalElasticsearchClient) -> list[str]:
+    instance_aliases = es_client.es_instance.indices.get_alias(index='*')
+    aliased_indexes: list[str] = []
+    for index_name, res in instance_aliases.items():
+        index_aliases: dict = res.get("aliases")
+        if index_aliases.keys():
+            aliased_indexes.append(index_name)
+    return aliased_indexes
+
+
+def storage_for_index(es_client: LocalElasticsearchClient, index: str) -> int:
+    stats = es_client.es_instance.indices.stats(index=index, metric='store')
+    size_in_bytes = stats['indices'][index]['total']['store']['size_in_bytes']
+    return size_in_bytes
+
+
+def main():
+    print("\n\n === ES Start == \n\n")
+
+    es_client = LocalElasticsearchClient(None)
+
+    all_indexes = es_client.list_all_indices()
+
+    indexes_to_preserve = find_aliased_indexes(es_client)
+    if not confirm(f"Preserving indexes: {indexes_to_preserve}"):
+        return
+
+    indexes_to_clear = [
+        index for index in all_indexes
+        if index not in indexes_to_preserve
+        and "address" in index
+    ]
+    
+    for index_to_clear in indexes_to_clear:
+        if index_to_clear in all_indexes:
+            size_in_bytes = storage_for_index(es_client, index_to_clear)
+            formatted_size = f"{size_in_bytes:_}"
+            if confirm(f"Delete index {index_to_clear} with {formatted_size} bytes of data?"):
+                es_client.delete_index(index_to_clear)
+        else:
+            print(f"Index {index_to_clear} not found.")
+
+
+
+
+if __name__ == "__main__":
+    main()

--- a/aws/database/opensearch/addresses/scripts/clear_unused_indexes.py
+++ b/aws/database/opensearch/addresses/scripts/clear_unused_indexes.py
@@ -36,13 +36,11 @@ def main():
     ]
     
     for index_to_clear in indexes_to_clear:
-        if index_to_clear in all_indexes:
-            size_in_bytes = storage_for_index(es_client, index_to_clear)
-            formatted_size = f"{size_in_bytes:_}"
-            if confirm(f"Delete index {index_to_clear} with {formatted_size} bytes of data?"):
-                es_client.delete_index(index_to_clear)
-        else:
-            print(f"Index {index_to_clear} not found.")
+        size_in_bytes = storage_for_index(es_client, index_to_clear)
+        formatted_size = f"{size_in_bytes:_}"
+        if confirm(f"Delete index {index_to_clear} with {formatted_size} bytes of data?"):
+            es_client.delete_index(index_to_clear)
+
 
 
 

--- a/aws/database/opensearch/addresses/scripts/clear_unused_indexes.py
+++ b/aws/database/opensearch/addresses/scripts/clear_unused_indexes.py
@@ -1,8 +1,20 @@
+"""
+This script or an adaptation of it can be used to identify and clean any Elasticsearch indexes which are not attached to aliases.
+The issue this was designed to solve was that the Addresses Elasticsearch had run out of storage and as a result
+write operations to it had started to fail.
+This script remedied this by identifying indexes which were not aliased (i.e. that were unused by the Addresses API) to clear them.
+The addresses API only fetched scripts from the hackney_addresses and national_addresses aliases, so any indexes not aliased to these were considered safe to delete.
+
+As background, overnight processes are run on the addresses API that create new indexes and alias them to the hackney_addresses and national_addresses aliases
+For more context, see: https://github.com/LBHackney-IT/addresses-api/blob/master/docs/elasticsearch_setup.md
+"""
+
 from aws.database.opensearch.client.elasticsearch_client import LocalElasticsearchClient
 from utils.confirm import confirm
 
 
 def find_aliased_indexes(es_client: LocalElasticsearchClient) -> list[str]:
+    """Returns the names of all indexes that are aliased"""
     instance_aliases = es_client.es_instance.indices.get_alias(index='*')
     aliased_indexes: list[str] = []
     for index_name, res in instance_aliases.items():
@@ -13,6 +25,7 @@ def find_aliased_indexes(es_client: LocalElasticsearchClient) -> list[str]:
 
 
 def storage_for_index(es_client: LocalElasticsearchClient, index: str) -> int:
+    """Returns the storage usage in bytes for a given index"""
     stats = es_client.es_instance.indices.stats(index=index, metric='store')
     size_in_bytes = stats['indices'][index]['total']['store']['size_in_bytes']
     return size_in_bytes

--- a/aws/database/opensearch/client/elasticsearch_client.py
+++ b/aws/database/opensearch/client/elasticsearch_client.py
@@ -2,6 +2,8 @@ import elasticsearch
 from elasticsearch import Elasticsearch
 
 import urllib3
+
+# Suppress warnings about insecure connections - this is because we're connecting to localhost and not using SSL
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 class LocalElasticsearchClient:

--- a/aws/database/opensearch/client/elasticsearch_client.py
+++ b/aws/database/opensearch/client/elasticsearch_client.py
@@ -1,6 +1,8 @@
 import elasticsearch
 from elasticsearch import Elasticsearch
 
+import urllib3
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 class LocalElasticsearchClient:
     def __init__(self, index: str | None, port: int = 3333):
@@ -10,7 +12,7 @@ class LocalElasticsearchClient:
         :param index: Index to connect to
         """
         self.port = port
-        self.es_instance = Elasticsearch(f"https://localhost:{port}", verify_certs=False, index=index)
+        self.es_instance = Elasticsearch(hosts=[{'host': 'localhost', 'port': port}], use_ssl=True, verify_certs=False, index=index)
         self._check_connection()
         self._index = index
 
@@ -19,7 +21,7 @@ class LocalElasticsearchClient:
 
         if not self.es_instance.indices.exists(index):
             raise ValueError(f"Index {index} does not exist. Valid indices are {self.list_all_indices()}")
-
+        
     def get(self, doc_id: str) -> dict:
         """Return a document in an index by its ID"""
         return self.es_instance.get(index=self._index, id=doc_id)
@@ -61,7 +63,7 @@ class LocalElasticsearchClient:
         }
         return self.query(query, size)
 
-    def set_attribute(self, doc_id: str, attribute: str, value: str | dict[str:str]):
+    def set_attribute(self, doc_id: str, attribute: str, value: str | dict[str,str]):
         """Set an attribute for a document in an index - use a dict for nested properties"""
         self.es_instance.update(index=self._index, id=doc_id, body={"doc": {attribute: value}})
 


### PR DESCRIPTION
[HPT-33](https://hackney.atlassian.net/browse/HPT-33)

The addresses Elasticsearch had filled up, due to having many historic unused elasticsearch indexes for addresses that had not been aliased.

This script was used to clear out the unaliased (and thus inaccessible) historic data in order to free up storage and unblock the automated re-indexing processes.

[HPT-33]: https://hackney.atlassian.net/browse/HPT-33?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ