### PR TITLE
Fix ggshield and formatting

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,4 +9,6 @@ RUN sh scripts/1_pre_requirements.sh
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 
+RUN pipx install ggshield
+
 RUN sh scripts/2_post_requirements.sh

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/python
 {
-	"name": "Python 3",
+	"name": "MTFH Scripts",
 	"build": {
 		"dockerfile": "Dockerfile",
 		"context": ".."
@@ -17,7 +17,11 @@
 				"ms-vscode.makefile-tools",
 				"ms-python.black-formatter",
 				"tamasfe.even-better-toml",
-				"lfm.vscode-makefile-term"			]
+				"lfm.vscode-makefile-term",
+				"ms-vsliveshare.vsliveshare",
+				"ms-python.python",
+				"ms-python.flake8"
+			]
 		}
 	},
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,4 +4,8 @@
     "[json]": {
         "editor.defaultFormatter": "vscode.json-language-features"
     },
+    "editor.formatOnSave": true,
+    "flake8.args": [
+        "--max-line-length=200"
+    ]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto3>=1.26.117
 botocore>=1.29.112
-mypy-boto3-dynamodb>=1.26.115
+mypy-boto3-dynamodb>=1.34.97
 mypy-boto3-ssm>=1.26.97
 mypy-boto3-opensearch>=1.34.1
 boto3-stubs>=1.26.117


### PR DESCRIPTION
GGshield wasn't running reliably in the devcontainer - needs to be installed and attached to pre-commit hook

Also update DynamoDB client version to allow more operations (was used in an uncommitted script)

Switch to flake8 formatter which is more Pythonic than Pylance especially with the inconsistent type annotations of Boto3