### PR TITLE
HPT-726: Script to retrieve RentGroup data from Assets DynamoDb

### DIFF
--- a/aws/database/dynamodb/scripts/asset_table/get_asset_rent_groups.py
+++ b/aws/database/dynamodb/scripts/asset_table/get_asset_rent_groups.py
@@ -1,38 +1,60 @@
 """
-A script to retrieve assetId and rentGroup from a DynamoDB table and export it to a CSV file.
+A script to retrieve assetId and rentGroup from the Assets DynamoDB table
+And export the results to either:
+1)  a CSV file.
+2)  a SQL file for importing into a database.
 The script scans the DynamoDB table, retrieves the specified attributes, and handles pagination if necessary.
 """
 
 import boto3
 import csv
+import argparse
 from mypy_boto3_dynamodb.service_resource import Table
 
-session = boto3.Session(profile_name="housingdev")
+# File format argument
+fileFormat = "sql"  # argument "csv" for CSV file - or "sql" for SQL file
 
-# Initialize DynamoDB resource
+# Change the profile name for the account here
+profileName = "housingprod"
+session = boto3.Session(profile_name=profileName)
+# Initialize session and DynamoDB
 dynamodb = session.resource("dynamodb")
 table: Table = dynamodb.Table("Assets")
 
-# Scan the table - specifying the attributes to retrieve
+# Scan the table for assetId and rentGroup
 response = table.scan(ProjectionExpression="assetId, rentGroup")
 items = response["Items"]
 
-# Handle pagination (if there are more than 1MB of items)
+# Handle pagination
 while "LastEvaluatedKey" in response:
     response = table.scan(ExclusiveStartKey=response["LastEvaluatedKey"])
     items.extend(response["Items"])
 
-# Extract assetId and rentGroup (default rentGroup to empty string if missing)
+# Filter and clean data
 filtered_data = [
     {"assetId": item["assetId"], "rentGroup": item.get("rentGroup", "")}
     for item in items
     if item.get("assetId") is not None
 ]
 
-# Write the filtered data to CSV (tab-separated)
-with open("assets_export.csv", mode="w", newline="") as file:
-    writer = csv.DictWriter(file, fieldnames=["assetId", "rentGroup"], delimiter="\t")
-    writer.writeheader()
-    writer.writerows(filtered_data)
+# Output based on selected format
+if fileFormat == "csv":
+    with open(f"assets_export_{profileName}.csv", mode="w", newline="") as file:
+        writer = csv.DictWriter(
+            file, fieldnames=["assetId", "rentGroup"], delimiter="\t"
+        )
+        writer.writeheader()
+        writer.writerows(filtered_data)
+    print(f"CSV file created: assets_export_{profileName}.csv")
 
-print("CSV file created: assets_export.csv")
+elif fileFormat == "sql":
+    with open(f"asset_rentgroup_ref_{profileName}.sql", mode="w") as file:
+        for row in filtered_data:
+            asset_id = str(row["assetId"]).replace("'", "''")
+            rent_group = str(row["rentGroup"]).replace("'", "''")
+            if rent_group == "":
+                sql = f"INSERT INTO AssetRentGroupRefs (prop_ref, rentgroup) VALUES ('{asset_id}', NULL);\n"
+            else:
+                sql = f"INSERT INTO AssetRentGroupRefs (prop_ref, rentgroup) VALUES ('{asset_id}', '{rent_group}');\n"
+            file.write(sql)
+    print(f"SQL file created: asset_rentgroup_ref_{profileName}.sql")

--- a/aws/database/dynamodb/scripts/asset_table/get_asset_rent_groups.py
+++ b/aws/database/dynamodb/scripts/asset_table/get_asset_rent_groups.py
@@ -1,0 +1,38 @@
+"""
+A script to retrieve assetId and rentGroup from a DynamoDB table and export it to a CSV file.
+The script scans the DynamoDB table, retrieves the specified attributes, and handles pagination if necessary.
+"""
+
+import boto3
+import csv
+from mypy_boto3_dynamodb.service_resource import Table
+
+session = boto3.Session(profile_name="housingdev")
+
+# Initialize DynamoDB resource
+dynamodb = session.resource("dynamodb")
+table: Table = dynamodb.Table("Assets")
+
+# Scan the table - specifying the attributes to retrieve
+response = table.scan(ProjectionExpression="assetId, rentGroup")
+items = response["Items"]
+
+# Handle pagination (if there are more than 1MB of items)
+while "LastEvaluatedKey" in response:
+    response = table.scan(ExclusiveStartKey=response["LastEvaluatedKey"])
+    items.extend(response["Items"])
+
+# Extract assetId and rentGroup (default rentGroup to empty string if missing)
+filtered_data = [
+    {"assetId": item["assetId"], "rentGroup": item.get("rentGroup", "")}
+    for item in items
+    if item.get("assetId") is not None
+]
+
+# Write the filtered data to CSV (tab-separated)
+with open("assets_export.csv", mode="w", newline="") as file:
+    writer = csv.DictWriter(file, fieldnames=["assetId", "rentGroup"], delimiter="\t")
+    writer.writeheader()
+    writer.writerows(filtered_data)
+
+print("CSV file created: assets_export.csv")


### PR DESCRIPTION
A script to retrieve assetId and rentGroup from the Assets DynamoDB table
And export the results to either:

1. a CSV file.
2. a SQL file for importing into a database.

The script scans the DynamoDB table, retrieves the specified attributes, and handles pagination if necessary.