### PR TITLE
Add try catch clause to handle params that do not exist at target

### DIFF
--- a/aws/ssm/copy_ssm_parameters.py
+++ b/aws/ssm/copy_ssm_parameters.py
@@ -70,9 +70,12 @@ def migrate_parameters(parameters: list[ParameterTypeDef]):
         print(parameter["Name"])
 
         # Check if parameter already exists in target account - skip if values match
-        existing_param = ssm_target.get_parameter(
-            Name=parameter["Name"], WithDecryption=True
-        ).get("Parameter")
+        try:
+            existing_param = ssm_target.get_parameter(
+                Name=parameter["Name"], WithDecryption=True
+            ).get("Parameter")
+        except:     
+            existing_param = None
         if existing_param and "Value" in existing_param:
             print(f"Param {parameter['Name']} already: {existing_param['Value']}")
             if existing_param["Value"] == parameter["Value"]:


### PR DESCRIPTION
As noticed yesterday by Adam and myself, this would fail when the param does not exist at target.
The try catch avoids that.